### PR TITLE
feat: add config and hub clients with updating

### DIFF
--- a/packages/indexer/src/main.ts
+++ b/packages/indexer/src/main.ts
@@ -40,17 +40,22 @@ export async function Main(
     );
     running = false;
   });
-  const providerUrls: string[] = Object.values(
+  const spokePoolProviderUrls: string[] = Object.values(
     acrossConstants.MAINNET_CHAIN_IDs,
   )
-    .map((chainId) => env[`INDEXER_PROVIDER_URL_${chainId}`])
+    .map((chainId) => env[`INDEXER_SPOKEPOOL_PROVIDER_URL_${chainId}`])
     .filter((x): x is string => !!x);
 
   assert(
-    providerUrls.length > 0,
-    "Must provide a url for at least one provider on one chain, for example: INDEXER_PROVIDER_URL_1",
+    spokePoolProviderUrls.length > 0,
+    "Must provide a url for at least one provider on one chain, for example: INDEXER_SPOKEPOOL_PROVIDER_URL_1",
   );
 
+  assert(
+    env.INDEXER_HUBPOOL_PROVIDER_URL,
+    "requires INDEXER_HUBPOOL_PROVIDER_URL",
+  );
+  const hubPoolProviderUrl = env.INDEXER_HUBPOOL_PROVIDER_URL;
   // optional redis config
   const redisConfig =
     env.INDEXER_REDIS_HOST && env.INDEXER_REDIS_PORT
@@ -67,14 +72,17 @@ export async function Main(
   logger.info({
     message: "Starting indexer",
     redisConfig,
-    providerUrls,
+    spokePoolProviderUrls,
+    hubPoolProviderUrl,
   });
   const depositIndexer = await services.deposits.Indexer({
-    providerUrls,
+    spokePoolProviderUrls,
+    hubPoolProviderUrl,
     logger,
     redis,
   });
 
+  // TODO: add looping to keep process going
   // do {
   logger.info("index loop starting");
   await depositIndexer(Date.now());

--- a/packages/indexer/src/services/deposits.ts
+++ b/packages/indexer/src/services/deposits.ts
@@ -92,12 +92,13 @@ export async function getConfigStoreClient(params: GetConfigStoreClientParams) {
     provider,
   );
   let lastProcessedBlockNumber: number = deployedBlockNumber;
-  if (redis) {
-    lastProcessedBlockNumber = Number(
-      (await redis.get(getConfigStoreLastBlockSearchedKey(chainId))) ??
-        lastProcessedBlockNumber,
-    );
-  }
+  // for now we will always process all config store events.
+  // if (redis) {
+  //   lastProcessedBlockNumber = Number(
+  //     (await redis.get(getConfigStoreLastBlockSearchedKey(chainId))) ??
+  //       lastProcessedBlockNumber,
+  //   );
+  // }
   const eventSearchConfig = {
     fromBlock: lastProcessedBlockNumber,
     maxBlockLookBack,

--- a/packages/indexer/src/services/deposits.ts
+++ b/packages/indexer/src/services/deposits.ts
@@ -40,7 +40,7 @@ export async function getSpokeClient(
   let lastProcessedBlockNumber: number = deployedBlockNumber;
   if (redis) {
     lastProcessedBlockNumber = Number(
-      (await redis.get(getSpokePoolLastBlockSearchedKey(chainId))) ??
+      (await redis.get(getLastBlockSearchedKey("spokePool", chainId))) ??
         lastProcessedBlockNumber,
     );
   }
@@ -95,7 +95,7 @@ export async function getConfigStoreClient(params: GetConfigStoreClientParams) {
   // for now we will always process all config store events.
   // if (redis) {
   //   lastProcessedBlockNumber = Number(
-  //     (await redis.get(getConfigStoreLastBlockSearchedKey(chainId))) ??
+  //     (await redis.get(getLastBlockSearchedKey('configStore',chainId))) ??
   //       lastProcessedBlockNumber,
   //   );
   // }
@@ -134,7 +134,7 @@ export async function getHubPoolClient(params: GetHubPoolClientParams) {
   let lastProcessedBlockNumber: number = deployedBlockNumber;
   if (redis) {
     lastProcessedBlockNumber = Number(
-      (await redis.get(getHubPoolLastBlockSearchedKey(chainId))) ??
+      (await redis.get(getLastBlockSearchedKey("hubPool", chainId))) ??
         lastProcessedBlockNumber,
     );
   }
@@ -151,26 +151,13 @@ export async function getHubPoolClient(params: GetHubPoolClientParams) {
     eventSearchConfig,
   );
 }
-function getSpokePoolLastBlockSearchedKey(chainId: number): string {
+function getLastBlockSearchedKey(
+  clientName: "hubPool" | "spokePool" | "configStore",
+  chainId: number,
+): string {
   return [
     "depositIndexer",
-    "spokePool",
-    "lastProcessedBlockNumber",
-    chainId,
-  ].join("~");
-}
-function getConfigStoreLastBlockSearchedKey(chainId: number): string {
-  return [
-    "depositIndexer",
-    "configStore",
-    "lastProcessedBlockNumber",
-    chainId,
-  ].join("~");
-}
-function getHubPoolLastBlockSearchedKey(chainId: number): string {
-  return [
-    "depositIndexer",
-    "hubPool",
+    clientName,
     "lastProcessedBlockNumber",
     chainId,
   ].join("~");
@@ -246,7 +233,7 @@ export async function Indexer(config: Config) {
     });
     if (redis) {
       await redis.set(
-        getHubPoolLastBlockSearchedKey(chainId),
+        getLastBlockSearchedKey("hubPool", chainId),
         latestBlockSearched,
       );
     }
@@ -261,12 +248,13 @@ export async function Indexer(config: Config) {
       chainId,
       latestBlockSearched,
     });
-    if (redis) {
-      await redis.set(
-        getConfigStoreLastBlockSearchedKey(chainId),
-        latestBlockSearched,
-      );
-    }
+    // remove this for now
+    // if (redis) {
+    //   await redis.set(
+    //     getConfigStoreLastBlockSearchedKey(chainId),
+    //     latestBlockSearched,
+    //   );
+    // }
   }
   async function updateSpokePool(
     now: number,
@@ -289,7 +277,7 @@ export async function Indexer(config: Config) {
     });
     if (redis) {
       await redis.set(
-        getSpokePoolLastBlockSearchedKey(chainId),
+        getLastBlockSearchedKey("spokePool", chainId),
         latestBlockSearched,
       );
     }

--- a/packages/indexer/src/services/deposits.ts
+++ b/packages/indexer/src/services/deposits.ts
@@ -3,19 +3,20 @@ import {
   getDeployedAddress,
   getDeployedBlockNumber,
   SpokePool__factory as SpokePoolFactory,
+  HubPool__factory as HubPoolFactory,
+  AcrossConfigStore__factory as AcrossConfigStoreFactory,
 } from "@across-protocol/contracts";
+import * as acrossConstants from "@across-protocol/constants";
 import * as across from "@across-protocol/sdk";
 import winston from "winston";
 import Redis from "ioredis";
 
 import { providers, Contract } from "ethers";
 
-type Config = {
-  providerUrls: string[];
-  maxBlockLookBack?: number;
-  logger: winston.Logger;
-  redis: Redis | undefined;
-};
+// Maximum supported version of the configuration loaded into the Across ConfigStore.
+// It protects bots from running outdated code against newer version of the on-chain config store.
+// @dev Incorrectly setting this value may lead to incorrect behaviour and potential loss of funds.
+export const CONFIG_STORE_VERSION = 4;
 
 type GetSpokeClientParams = {
   provider: providers.Provider;
@@ -23,11 +24,13 @@ type GetSpokeClientParams = {
   redis: Redis | undefined;
   maxBlockLookBack: number;
   chainId: number;
+  hubPoolClient: across.clients.HubPoolClient;
 };
 export async function getSpokeClient(
   params: GetSpokeClientParams,
 ): Promise<across.clients.SpokePoolClient> {
-  const { provider, logger, redis, maxBlockLookBack, chainId } = params;
+  const { provider, logger, redis, maxBlockLookBack, chainId, hubPoolClient } =
+    params;
   const address = getDeployedAddress("SpokePool", chainId);
   const deployedBlockNumber = getDeployedBlockNumber("SpokePool", chainId);
 
@@ -39,7 +42,7 @@ export async function getSpokeClient(
   let lastProcessedBlockNumber: number = deployedBlockNumber;
   if (redis) {
     lastProcessedBlockNumber = Number(
-      (await redis.get(getLastBlockSearchedKey(chainId))) ??
+      (await redis.get(getSpokePoolLastBlockSearchedKey(chainId))) ??
         lastProcessedBlockNumber,
     );
   }
@@ -65,13 +68,91 @@ export async function getSpokeClient(
   return new across.clients.SpokePoolClient(
     logger,
     spokePoolContract,
-    null,
+    hubPoolClient,
     chainId,
     deployedBlockNumber,
     eventSearchConfig,
   );
 }
-function getLastBlockSearchedKey(chainId: number): string {
+type GetConfigStoreClientParams = {
+  provider: providers.Provider;
+  logger: winston.Logger;
+  redis: Redis | undefined;
+  maxBlockLookBack: number;
+  chainId: number;
+};
+export async function getConfigStoreClient(params: GetConfigStoreClientParams) {
+  const { provider, logger, redis, maxBlockLookBack, chainId } = params;
+  const address = getDeployedAddress("AcrossConfigStore", chainId);
+  const deployedBlockNumber = getDeployedBlockNumber(
+    "AcrossConfigStore",
+    chainId,
+  );
+  const configStoreContract = new Contract(
+    address,
+    AcrossConfigStoreFactory.abi,
+    provider,
+  );
+  let lastProcessedBlockNumber: number = deployedBlockNumber;
+  if (redis) {
+    lastProcessedBlockNumber = Number(
+      (await redis.get(getConfigStoreLastBlockSearchedKey(chainId))) ??
+        lastProcessedBlockNumber,
+    );
+  }
+  const eventSearchConfig = {
+    fromBlock: lastProcessedBlockNumber,
+    maxBlockLookBack,
+  };
+  return new across.clients.AcrossConfigStoreClient(
+    logger,
+    configStoreContract,
+    eventSearchConfig,
+    CONFIG_STORE_VERSION,
+  );
+}
+type GetHubPoolClientParams = {
+  provider: providers.Provider;
+  logger: winston.Logger;
+  redis: Redis | undefined;
+  maxBlockLookBack: number;
+  chainId: number;
+  configStoreClient: across.clients.AcrossConfigStoreClient;
+};
+export async function getHubPoolClient(params: GetHubPoolClientParams) {
+  const {
+    provider,
+    logger,
+    redis,
+    maxBlockLookBack,
+    chainId,
+    configStoreClient,
+  } = params;
+  const address = getDeployedAddress("HubPool", chainId);
+  const deployedBlockNumber = getDeployedBlockNumber("HubPool", chainId);
+
+  const hubPoolContract = new Contract(address, HubPoolFactory.abi, provider);
+  let lastProcessedBlockNumber: number = deployedBlockNumber;
+  if (redis) {
+    lastProcessedBlockNumber = Number(
+      (await redis.get(getHubPoolLastBlockSearchedKey(chainId))) ??
+        lastProcessedBlockNumber,
+    );
+  }
+  const eventSearchConfig = {
+    fromBlock: lastProcessedBlockNumber,
+    maxBlockLookBack,
+  };
+  return new across.clients.HubPoolClient(
+    logger,
+    hubPoolContract,
+    configStoreClient,
+    deployedBlockNumber,
+    chainId,
+    eventSearchConfig,
+  );
+}
+function getSpokePoolLastBlockSearchedKey(chainId: number): string {
   return [
     "depositIndexer",
     "spokePool",
@@ -79,15 +160,64 @@ function getLastBlockSearchedKey(chainId: number): string {
     chainId,
   ].join("~");
 }
+function getConfigStoreLastBlockSearchedKey(chainId: number): string {
+  return [
+    "depositIndexer",
+    "configStore",
+    "lastProcessedBlockNumber",
+    chainId,
+  ].join("~");
+}
+function getHubPoolLastBlockSearchedKey(chainId: number): string {
+  return [
+    "depositIndexer",
+    "hubPool",
+    "lastProcessedBlockNumber",
+    chainId,
+  ].join("~");
+}
+
+type Config = {
+  spokePoolProviderUrls: string[];
+  hubPoolProviderUrl: string;
+  maxBlockLookBack?: number;
+  logger: winston.Logger;
+  redis: Redis | undefined;
+};
 
 export async function Indexer(config: Config) {
-  const { providerUrls, maxBlockLookBack = 10000, logger, redis } = config;
+  const {
+    spokePoolProviderUrls,
+    hubPoolProviderUrl,
+    maxBlockLookBack = 10000,
+    logger,
+    redis,
+  } = config;
 
   // const pg = config.postgres ? initPostgres(config.postgres) : undefined;
 
+  const hubPoolProvider = new providers.JsonRpcProvider(hubPoolProviderUrl);
+  const hubPoolNetworkInfo = await hubPoolProvider.getNetwork();
+
+  const configStoreClient = await getConfigStoreClient({
+    provider: hubPoolProvider,
+    logger,
+    redis,
+    maxBlockLookBack,
+    chainId: hubPoolNetworkInfo.chainId,
+  });
+  const hubPoolClient = await getHubPoolClient({
+    provider: hubPoolProvider,
+    logger,
+    redis,
+    maxBlockLookBack,
+    chainId: hubPoolNetworkInfo.chainId,
+    configStoreClient,
+  });
+
   const spokeClientEntries: [number, across.clients.SpokePoolClient][] =
     await Promise.all(
-      providerUrls.map(async (providerUrl) => {
+      spokePoolProviderUrls.map(async (providerUrl) => {
         const provider = new providers.JsonRpcProvider(providerUrl);
         const networkInfo = await provider.getNetwork();
         const { chainId } = networkInfo;
@@ -99,12 +229,47 @@ export async function Indexer(config: Config) {
             redis,
             maxBlockLookBack,
             chainId,
+            hubPoolClient,
           }),
         ];
       }),
     );
 
-  async function update(
+  async function updateHubPool(now: number, chainId: number) {
+    logger.info("Starting hub pool client update");
+    await hubPoolClient.update();
+    // TODO: store any data we need for hubpool in index
+    const latestBlockSearched = hubPoolClient.latestBlockSearched;
+    logger.info({
+      message: "Finished updating hub pool client",
+      chainId,
+      latestBlockSearched,
+    });
+    if (redis) {
+      await redis.set(
+        getHubPoolLastBlockSearchedKey(chainId),
+        latestBlockSearched,
+      );
+    }
+  }
+  async function updateConfigStore(now: number, chainId: number) {
+    logger.info("Starting config store update");
+    await configStoreClient.update();
+    // TODO: store any data we need for configs in index
+    const latestBlockSearched = configStoreClient.latestBlockSearched;
+    logger.info({
+      message: "Finished updating config store client",
+      chainId,
+      latestBlockSearched,
+    });
+    if (redis) {
+      await redis.set(
+        getConfigStoreLastBlockSearchedKey(chainId),
+        latestBlockSearched,
+      );
+    }
+  }
+  async function updateSpokePool(
     now: number,
     chainId: number,
     spokeClient: across.clients.SpokePoolClient,
@@ -114,6 +279,7 @@ export async function Indexer(config: Config) {
       chainId,
     });
     await spokeClient.update();
+    // TODO: store any data we need for configs in index
     const latestBlockSearched = spokeClient.latestBlockSearched;
     logger.info({
       message: "Finished updating spoke client",
@@ -123,13 +289,18 @@ export async function Indexer(config: Config) {
       deposits: spokeClient.getDeposits().length,
     });
     if (redis) {
-      await redis.set(getLastBlockSearchedKey(chainId), latestBlockSearched);
+      await redis.set(
+        getSpokePoolLastBlockSearchedKey(chainId),
+        latestBlockSearched,
+      );
     }
   }
 
   return async function updateAll(now: number) {
     for (const [chainId, spokeClient] of spokeClientEntries) {
-      await update(now, chainId, spokeClient);
+      await updateConfigStore(now, hubPoolNetworkInfo.chainId);
+      await updateHubPool(now, hubPoolNetworkInfo.chainId);
+      await updateSpokePool(now, chainId, spokeClient);
     }
   };
 }


### PR DESCRIPTION
# motivation
we want to add hubpool client to the spoke pool clients

# changes
This adds a new env for hubpool provider, and changes the env names for spoke pool providers. we use this to instanciate both across config and hubpool client and update them before attempting to update spoke pool clients. 

# todo
- add in postgres persistence
- retry/cache rpc provider