### PR TITLE
fix: fix build cache path

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": ["dist/**"] 
     },
     "lint": {
     },


### PR DESCRIPTION
The `outputs` key tells Turborepo files and directories it should cache when the task has successfully completed. The paths that are currently set in this list don't correspond to the output path of the `tsc` compiler.

After this change, if no package/app is changed, the build process consists of cache hits only, the build time being a matter of hundreds of milliseconds

<img width="652" alt="Screenshot 2024-08-22 at 14 13 38" src="https://github.com/user-attachments/assets/6a0f83f3-f846-4aa0-b8b5-9817d1f5f6d8">
