### PR TITLE
fix(indexer): fix retry provider logic

### DIFF
--- a/packages/indexer/src/main.ts
+++ b/packages/indexer/src/main.ts
@@ -125,6 +125,7 @@ export async function Main(
     postgresConfig,
     spokePoolProviderUrls,
     hubPoolProviderUrl,
+    retryProviderConfig,
   });
   const depositIndexer = await services.deposits.Indexer({
     spokePoolProviderUrls,

--- a/packages/indexer/src/redisCache.ts
+++ b/packages/indexer/src/redisCache.ts
@@ -4,7 +4,9 @@ import Redis from "ioredis";
 export class RedisCache implements across.interfaces.CachingMechanismInterface {
   constructor(private redis: Redis) {}
   async get<ObjectType>(key: string): Promise<ObjectType | null> {
-    return this.redis.get(key) as ObjectType | null;
+    const result = await this.redis.get(key);
+    if (result === null) return result;
+    return JSON.parse(result);
   }
   async set<ObjectType>(
     key: string,

--- a/packages/indexer/src/services/deposits.ts
+++ b/packages/indexer/src/services/deposits.ts
@@ -141,6 +141,12 @@ export async function getHubPoolClient(params: GetHubPoolClientParams) {
     fromBlock: lastProcessedBlockNumber,
     maxBlockLookBack,
   };
+  logger.info({
+    message: "Initializing hubpool",
+    chainId,
+    redis: !!redis,
+    ...eventSearchConfig,
+  });
   return new across.clients.HubPoolClient(
     logger,
     hubPoolContract,
@@ -180,7 +186,7 @@ type RetryProviderDeps = {
 };
 function getRetryProvider(params: RetryProviderConfig & RetryProviderDeps) {
   return new across.providers.RetryProvider(
-    [[params.providerUrl], [undefined]],
+    [[params.providerUrl, params.chainId]],
     params.chainId,
     params.nodeQuorumThreshold,
     params.retries,


### PR DESCRIPTION
# motivation
We want to make sure retry provider allows us to capture all the events without timeout errors, also retry provider was starting up with errors

# changes
Retry provider seems to solve the issue of timeouts on spokepool by setting maxconcurrency low, have only tested with a value of 1.  There were 2 fixes needed: one was with chain id not being passed into config, the other was with the redis cache not parsing json results.  There are other issues to do with caching the latest block for hubpool, but will address this in future pr

# todo
We need to make sure we arent caching block ranges for hubpool until corresponding spoke pool actually succeeds in updating the same range, its capture in this issue: https://linear.app/uma/issue/ACX-2597/improve-indexing