### PR TITLE
feat: add hubpool event saving with block range checks

### DIFF
--- a/packages/indexer/src/main.ts
+++ b/packages/indexer/src/main.ts
@@ -124,6 +124,24 @@ async function getSpokePoolIndexerConfig(params: {
     redisKeyPrefix: `spokePoolIndexer:${spokePoolNetworkInfo.chainId}`,
   };
 }
+// utility call to create the spoke pool event indexer config
+async function getHubPoolIndexerConfig(params: {
+  retryProviderConfig: services.deposits.RetryProviderConfig;
+  hubPoolNetworkInfo: providers.Network;
+  hubPoolProviderUrl: string;
+}) {
+  const { retryProviderConfig, hubPoolProviderUrl, hubPoolNetworkInfo } =
+    params;
+  return {
+    retryProviderConfig,
+    hubConfig: {
+      chainId: hubPoolNetworkInfo.chainId,
+      providerUrl: hubPoolProviderUrl,
+      maxBlockLookBack: 10000,
+    },
+    redisKeyPrefix: `hubPoolIndexer:${hubPoolNetworkInfo.chainId}`,
+  };
+}
 
 export async function Main(
   env: Record<string, string | undefined>,
@@ -175,6 +193,18 @@ export async function Main(
   });
   const spokePoolIndexers: Array<services.spokePoolIndexer.SpokePoolIndexer> =
     [];
+  const hubPoolIndexerConfig = await getHubPoolIndexerConfig({
+    hubPoolNetworkInfo,
+    hubPoolProviderUrl,
+    retryProviderConfig,
+  });
+  // canonical hubpool indexer
+  const hubPoolIndexer = await services.hubPoolIndexer.HubPoolIndexer({
+    logger,
+    redis,
+    postgres,
+    ...hubPoolIndexerConfig,
+  });
   // instanciate multiple spoke pool event indexers
   for (const spokePoolProviderUrl of spokePoolProviderUrls) {
     const config = await getSpokePoolIndexerConfig({
@@ -199,8 +229,11 @@ export async function Main(
   let exitRequested = false;
   process.on("SIGINT", () => {
     if (!exitRequested) {
-      logger.info("\nPress Ctrl+C again to exit.");
+      logger.info(
+        "\nWait for shutdown, or press Ctrl+C again to forcefully exit.",
+      );
       spokePoolIndexers.map((s) => s.stop());
+      hubPoolIndexer.stop();
     } else {
       logger.info("\nForcing exit...");
       across.utils.delay(1).finally(() => process.exit());
@@ -211,6 +244,7 @@ export async function Main(
     message: "Running indexers",
     at: "Indexer#Main",
   });
+  await hubPoolIndexer.start(10);
   // start all indexers in parallel, will wait for them to complete, but they all loop independently
   const [bundleResults, ...spokeResults] = await Promise.allSettled([
     bundleProcessor(),

--- a/packages/indexer/src/services/hubPoolIndexer.ts
+++ b/packages/indexer/src/services/hubPoolIndexer.ts
@@ -1,0 +1,221 @@
+import { getDeployedBlockNumber } from "@across-protocol/contracts";
+import winston from "winston";
+import * as across from "@across-protocol/sdk";
+import Redis from "ioredis";
+import { DataSource } from "@repo/indexer-database";
+import { HubPoolRepository } from "../database/HubPoolRepository";
+import { differenceWith, isEqual } from "lodash";
+
+import { RangeQueryStore, Ranges } from "../redis/rangeQueryStore";
+import { RedisCache } from "../redis/redisCache";
+
+import * as utils from "../utils";
+
+type Config = {
+  logger: winston.Logger;
+  redis: Redis;
+  postgres: DataSource;
+  retryProviderConfig: utils.RetryProviderConfig;
+  hubConfig: {
+    chainId: number;
+    providerUrl: string;
+    maxBlockLookBack: number;
+  };
+  redisKeyPrefix: string;
+};
+export async function HubPoolIndexer(config: Config) {
+  const {
+    logger,
+    redis,
+    postgres,
+    retryProviderConfig,
+    redisKeyPrefix,
+    hubConfig,
+  } = config;
+
+  let stopRequested = false;
+
+  function makeId(...args: Array<string | number>) {
+    return [redisKeyPrefix, ...args].join(":");
+  }
+
+  const resolvedRangeStore = new RangeQueryStore({
+    redis,
+    prefix: makeId("rangeQuery", "resolved"),
+  });
+
+  const redisCache = new RedisCache(redis);
+  const hubPoolProvider = utils.getRetryProvider({
+    ...retryProviderConfig,
+    cache: redisCache,
+    logger,
+    ...hubConfig,
+  });
+  const configStoreProvider = utils.getRetryProvider({
+    ...retryProviderConfig,
+    cache: redisCache,
+    logger,
+    ...hubConfig,
+  });
+  const configStoreClient = await utils.getConfigStoreClient({
+    logger,
+    provider: configStoreProvider,
+    maxBlockLookBack: hubConfig.maxBlockLookBack,
+    chainId: hubConfig.chainId,
+  });
+  const hubPoolClient = await utils.getHubPoolClient({
+    configStoreClient,
+    provider: hubPoolProvider,
+    logger,
+    maxBlockLookBack: hubConfig.maxBlockLookBack,
+    chainId: hubConfig.chainId,
+  });
+
+  const hubPoolRepository = new HubPoolRepository(postgres, logger, true);
+
+  async function update() {
+    const allPendingQueries = await getUnprocessedRanges();
+    logger.info({
+      message: `Running hubpool indexer on ${allPendingQueries.length} block range requests`,
+    });
+    for (const query of allPendingQueries) {
+      if (stopRequested) break;
+      const [fromBlock, toBlock] = query;
+      try {
+        logger.info({
+          message: `Starting hubpool update for block range ${fromBlock} to ${toBlock}`,
+          query,
+        });
+        const events = await fetchEventsByRange(fromBlock, toBlock);
+        // TODO: may need to catch error to see if there is some data that exists in db already or change storage to overwrite any existing values
+        await storeEvents(events);
+
+        await resolvedRangeStore.setByRange(fromBlock, toBlock);
+        logger.info({
+          message: `Completed hubpool update for block range ${fromBlock} to ${toBlock}`,
+          query,
+        });
+      } catch (error) {
+        if (error instanceof Error) {
+          logger.error({
+            message: `Error hubpool updating for block range ${fromBlock} to ${toBlock}`,
+            query,
+            errorMessage: error.message,
+          });
+        } else {
+          // not an error type, throw it and crash app likely
+          throw error;
+        }
+      }
+    }
+  }
+  async function getUnprocessedRanges(toBlock?: number): Promise<Ranges> {
+    const deployedBlockNumber = getDeployedBlockNumber(
+      "HubPool",
+      hubConfig.chainId,
+    );
+    const latestBlockNumber =
+      toBlock ?? (await hubPoolProvider.getBlockNumber());
+
+    const allPaginatedBlockRanges = across.utils.getPaginatedBlockRanges({
+      fromBlock: deployedBlockNumber,
+      toBlock: latestBlockNumber,
+      maxBlockLookBack: hubConfig.maxBlockLookBack,
+    });
+
+    const allQueries = await resolvedRangeStore.entries();
+    const resolvedRanges = allQueries.map(([, x]) => [x.fromBlock, x.toBlock]);
+    const needsProcessing = differenceWith(
+      allPaginatedBlockRanges,
+      resolvedRanges,
+      isEqual,
+    );
+
+    logger.info({
+      message: `${needsProcessing.length} block ranges need processing`,
+      deployedBlockNumber,
+      latestBlockNumber,
+    });
+
+    return needsProcessing;
+  }
+
+  async function fetchEventsByRange(fromBlock: number, toBlock: number) {
+    logger.info({
+      message: "updating config store client",
+      fromBlock,
+      toBlock,
+    });
+    await configStoreClient.update();
+    logger.info({
+      message: "updated config store client",
+      fromBlock,
+      toBlock,
+    });
+
+    logger.info({
+      message: "updating hubpool client",
+      fromBlock,
+      toBlock,
+    });
+    await hubPoolClient.update();
+    logger.info({
+      message: "updated hubpool client",
+      fromBlock,
+      toBlock,
+    });
+    const proposedRootBundleEvents = hubPoolClient.getProposedRootBundles();
+    const rootBundleCanceledEvents = hubPoolClient.getCancelledRootBundles();
+    const rootBundleDisputedEvents = hubPoolClient.getDisputedRootBundles();
+    const rootBundleExecutedEvents = hubPoolClient.getExecutedRootBundles();
+    return {
+      proposedRootBundleEvents,
+      rootBundleCanceledEvents,
+      rootBundleDisputedEvents,
+      rootBundleExecutedEvents,
+    };
+  }
+  async function storeEvents(params: {
+    proposedRootBundleEvents: across.interfaces.ProposedRootBundle[];
+    rootBundleCanceledEvents: across.interfaces.CancelledRootBundle[];
+    rootBundleDisputedEvents: across.interfaces.DisputedRootBundle[];
+    rootBundleExecutedEvents: across.interfaces.ExecutedRootBundle[];
+  }) {
+    const {
+      proposedRootBundleEvents,
+      rootBundleCanceledEvents,
+      rootBundleDisputedEvents,
+      rootBundleExecutedEvents,
+    } = params;
+    await hubPoolRepository.formatAndSaveProposedRootBundleEvents(
+      proposedRootBundleEvents,
+    );
+    await hubPoolRepository.formatAndSaveRootBundleCanceledEvents(
+      rootBundleCanceledEvents,
+    );
+    await hubPoolRepository.formatAndSaveRootBundleDisputedEvents(
+      rootBundleDisputedEvents,
+    );
+    await hubPoolRepository.formatAndSaveRootBundleExecutedEvents(
+      rootBundleExecutedEvents,
+    );
+  }
+
+  function stop() {
+    stopRequested = true;
+  }
+
+  async function start(delay: number) {
+    stopRequested = false;
+    do {
+      await update();
+      await across.utils.delay(delay);
+    } while (!stopRequested);
+  }
+  return {
+    update,
+    start,
+    stop,
+  };
+}
+export type HubPoolIndexer = Awaited<ReturnType<typeof HubPoolIndexer>>;

--- a/packages/indexer/src/services/index.ts
+++ b/packages/indexer/src/services/index.ts
@@ -1,3 +1,4 @@
 export * as deposits from "./deposits";
 export * as bundles from "./bundles";
 export * as spokePoolIndexer from "./spokePoolIndexer";
+export * as hubPoolIndexer from "./hubPoolIndexer";

--- a/packages/indexer/src/services/spokePoolIndexer.ts
+++ b/packages/indexer/src/services/spokePoolIndexer.ts
@@ -16,167 +16,13 @@ import { SpokePoolRepository } from "../database/SpokePoolRepository";
 import { differenceWith, isEqual } from "lodash";
 
 import { RangeQueryStore, Ranges } from "../redis/rangeQueryStore";
+import * as utils from "../utils";
 
-export const CONFIG_STORE_VERSION = 4;
-
-type GetSpokeClientParams = {
-  provider: providers.Provider;
-  logger: winston.Logger;
-  maxBlockLookBack: number;
-  fromBlock?: number;
-  toBlock?: number;
-  chainId: number;
-  hubPoolClient: across.clients.HubPoolClient;
-};
-
-export async function getSpokeClient(
-  params: GetSpokeClientParams,
-): Promise<across.clients.SpokePoolClient> {
-  const { provider, logger, maxBlockLookBack, chainId, hubPoolClient } = params;
-  const address = getDeployedAddress("SpokePool", chainId);
-  assert(address, `Unable to get spokepool address on chain ${chainId}`);
-  const deployedBlockNumber = getDeployedBlockNumber("SpokePool", chainId);
-
-  const toBlock = params.toBlock ?? (await provider.getBlockNumber());
-  const fromBlock = params.fromBlock ?? deployedBlockNumber;
-
-  const eventSearchConfig = {
-    fromBlock,
-    toBlock,
-    maxBlockLookBack,
-  };
-  logger.info({
-    message: "Initializing spoke pool",
-    chainId,
-    address,
-    deployedBlockNumber,
-    ...eventSearchConfig,
-    blockRangeSearched: toBlock - fromBlock,
-  });
-  const spokePoolContract = SpokePoolFactory.connect(address, provider);
-  return new across.clients.SpokePoolClient(
-    logger,
-    spokePoolContract,
-    hubPoolClient,
-    chainId,
-    deployedBlockNumber,
-    eventSearchConfig,
-  );
-}
-
-type GetConfigStoreClientParams = {
-  provider: providers.Provider;
-  logger: winston.Logger;
-  maxBlockLookBack: number;
-  chainId: number;
-};
-
-export async function getConfigStoreClient(params: GetConfigStoreClientParams) {
-  const { provider, logger, maxBlockLookBack, chainId } = params;
-  const address = getDeployedAddress("AcrossConfigStore", chainId);
-  const deployedBlockNumber = getDeployedBlockNumber(
-    "AcrossConfigStore",
-    chainId,
-  );
-  const configStoreContract = new Contract(
-    address,
-    AcrossConfigStoreFactory.abi,
-    provider,
-  );
-  let lastProcessedBlockNumber: number = deployedBlockNumber;
-  const eventSearchConfig = {
-    fromBlock: lastProcessedBlockNumber,
-    maxBlockLookBack,
-  };
-  return new across.clients.AcrossConfigStoreClient(
-    logger,
-    configStoreContract,
-    eventSearchConfig,
-    CONFIG_STORE_VERSION,
-  );
-}
-
-type GetHubPoolClientParams = {
-  provider: providers.Provider;
-  logger: winston.Logger;
-  maxBlockLookBack: number;
-  chainId: number;
-  configStoreClient: across.clients.AcrossConfigStoreClient;
-  // dont usually need to include these
-  fromBlock?: number;
-  toBlock?: number;
-};
-
-export async function getHubPoolClient(params: GetHubPoolClientParams) {
-  const { provider, logger, maxBlockLookBack, chainId, configStoreClient } =
-    params;
-  const address = getDeployedAddress("HubPool", chainId);
-  const deployedBlockNumber = getDeployedBlockNumber("HubPool", chainId);
-
-  const hubPoolContract = new Contract(address, HubPoolFactory.abi, provider);
-  const fromBlock = params.fromBlock ?? deployedBlockNumber;
-  const toBlock = params.toBlock ?? (await provider.getBlockNumber());
-
-  const eventSearchConfig = {
-    fromBlock,
-    toBlock,
-    maxBlockLookBack,
-  };
-  logger.info({
-    message: "Initializing hubpool",
-    chainId,
-    ...eventSearchConfig,
-    blockRangeSearched: toBlock - fromBlock,
-  });
-  return new across.clients.HubPoolClient(
-    logger,
-    hubPoolContract,
-    configStoreClient,
-    deployedBlockNumber,
-    chainId,
-    eventSearchConfig,
-  );
-}
-
-export type RetryProviderConfig = {
-  providerCacheNamespace: string;
-  maxConcurrency: number;
-  pctRpcCallsLogged: number;
-  standardTtlBlockDistance: number;
-  noTtlBlockDistance: number;
-  providerCacheTtl: number;
-  nodeQuorumThreshold: number;
-  retries: number;
-  delay: number;
-};
-type RetryProviderDeps = {
-  cache: across.interfaces.CachingMechanismInterface;
-  logger: winston.Logger;
-  providerUrl: string;
-  chainId: number;
-};
-function getRetryProvider(params: RetryProviderConfig & RetryProviderDeps) {
-  return new across.providers.RetryProvider(
-    [[params.providerUrl, params.chainId]],
-    params.chainId,
-    params.nodeQuorumThreshold,
-    params.retries,
-    params.delay,
-    params.maxConcurrency,
-    params.providerCacheNamespace,
-    params.pctRpcCallsLogged,
-    params.cache,
-    params.standardTtlBlockDistance,
-    params.noTtlBlockDistance,
-    params.providerCacheTtl,
-    params.logger,
-  );
-}
 type Config = {
   logger: winston.Logger;
   redis: Redis;
   postgres: DataSource;
-  retryProviderConfig: RetryProviderConfig;
+  retryProviderConfig: utils.RetryProviderConfig;
   configStoreConfig: {
     chainId: number;
     providerUrl: string;
@@ -206,6 +52,8 @@ export async function SpokePoolIndexer(config: Config) {
     configStoreConfig,
   } = config;
 
+  let stopRequested = false;
+
   function makeId(...args: Array<string | number>) {
     return [redisKeyPrefix, ...args].join(":");
   }
@@ -216,19 +64,19 @@ export async function SpokePoolIndexer(config: Config) {
   });
 
   const redisCache = new RedisCache(redis);
-  const hubPoolProvider = getRetryProvider({
+  const hubPoolProvider = utils.getRetryProvider({
     ...retryProviderConfig,
     cache: redisCache,
     logger,
     ...hubConfig,
   });
-  const configStoreProvider = getRetryProvider({
+  const configStoreProvider = utils.getRetryProvider({
     ...retryProviderConfig,
     cache: redisCache,
     logger,
     ...configStoreConfig,
   });
-  const spokePoolProvider = getRetryProvider({
+  const spokePoolProvider = utils.getRetryProvider({
     ...retryProviderConfig,
     cache: redisCache,
     logger,
@@ -241,13 +89,13 @@ export async function SpokePoolIndexer(config: Config) {
     true,
   );
 
-  const configStoreClient = await getConfigStoreClient({
+  const configStoreClient = await utils.getConfigStoreClient({
     logger,
     provider: configStoreProvider,
     maxBlockLookBack: configStoreConfig.maxBlockLookBack,
     chainId: configStoreConfig.chainId,
   });
-  const hubPoolClient = await getHubPoolClient({
+  const hubPoolClient = await utils.getHubPoolClient({
     configStoreClient,
     provider: hubPoolProvider,
     logger,
@@ -255,12 +103,13 @@ export async function SpokePoolIndexer(config: Config) {
     chainId: hubConfig.chainId,
   });
 
-  async function tick() {
+  async function update() {
     const allPendingQueries = await getUnprocessedRanges();
     logger.info({
       message: `Running indexer on ${allPendingQueries.length} block range requests`,
     });
     for (const query of allPendingQueries) {
+      if (stopRequested) break;
       const [fromBlock, toBlock] = query;
       try {
         logger.info({
@@ -346,7 +195,7 @@ export async function SpokePoolIndexer(config: Config) {
       toBlock,
     });
 
-    const spokeClient = await getSpokeClient({
+    const spokeClient = await utils.getSpokeClient({
       hubPoolClient,
       provider: spokePoolProvider,
       logger,
@@ -423,8 +272,6 @@ export async function SpokePoolIndexer(config: Config) {
     );
   }
 
-  let stopRequested = false;
-
   function stop() {
     stopRequested = true;
   }
@@ -432,12 +279,12 @@ export async function SpokePoolIndexer(config: Config) {
   async function start(delay: number) {
     stopRequested = false;
     do {
-      await tick();
+      await update();
       await across.utils.delay(delay);
     } while (!stopRequested);
   }
   return {
-    tick,
+    update,
     start,
     stop,
   };

--- a/packages/indexer/src/utils.ts
+++ b/packages/indexer/src/utils.ts
@@ -1,0 +1,171 @@
+import {
+  getDeployedAddress,
+  getDeployedBlockNumber,
+  SpokePool__factory as SpokePoolFactory,
+  HubPool__factory as HubPoolFactory,
+  AcrossConfigStore__factory as AcrossConfigStoreFactory,
+} from "@across-protocol/contracts";
+import winston from "winston";
+import * as across from "@across-protocol/sdk";
+import { providers, Contract } from "ethers";
+
+export const CONFIG_STORE_VERSION = 4;
+
+export type GetSpokeClientParams = {
+  provider: providers.Provider;
+  logger: winston.Logger;
+  maxBlockLookBack: number;
+  fromBlock?: number;
+  toBlock?: number;
+  chainId: number;
+  hubPoolClient: across.clients.HubPoolClient;
+};
+
+export async function getSpokeClient(
+  params: GetSpokeClientParams,
+): Promise<across.clients.SpokePoolClient> {
+  const { provider, logger, maxBlockLookBack, chainId, hubPoolClient } = params;
+  const address = getDeployedAddress("SpokePool", chainId);
+  const deployedBlockNumber = getDeployedBlockNumber("SpokePool", chainId);
+
+  const toBlock = params.toBlock ?? (await provider.getBlockNumber());
+  const fromBlock = params.fromBlock ?? deployedBlockNumber;
+
+  const eventSearchConfig = {
+    fromBlock,
+    toBlock,
+    maxBlockLookBack,
+  };
+  logger.info({
+    message: "Initializing spoke pool",
+    chainId,
+    address,
+    deployedBlockNumber,
+    ...eventSearchConfig,
+    blockRangeSearched: toBlock - fromBlock,
+  });
+  const spokePoolContract = new Contract(
+    address,
+    SpokePoolFactory.abi,
+    provider,
+  );
+  return new across.clients.SpokePoolClient(
+    logger,
+    spokePoolContract,
+    hubPoolClient,
+    chainId,
+    deployedBlockNumber,
+    eventSearchConfig,
+  );
+}
+
+export type GetConfigStoreClientParams = {
+  provider: providers.Provider;
+  logger: winston.Logger;
+  maxBlockLookBack: number;
+  chainId: number;
+};
+
+export async function getConfigStoreClient(params: GetConfigStoreClientParams) {
+  const { provider, logger, maxBlockLookBack, chainId } = params;
+  const address = getDeployedAddress("AcrossConfigStore", chainId);
+  const deployedBlockNumber = getDeployedBlockNumber(
+    "AcrossConfigStore",
+    chainId,
+  );
+  const configStoreContract = new Contract(
+    address,
+    AcrossConfigStoreFactory.abi,
+    provider,
+  );
+  let lastProcessedBlockNumber: number = deployedBlockNumber;
+  const eventSearchConfig = {
+    fromBlock: lastProcessedBlockNumber,
+    maxBlockLookBack,
+  };
+  return new across.clients.AcrossConfigStoreClient(
+    logger,
+    configStoreContract,
+    eventSearchConfig,
+    CONFIG_STORE_VERSION,
+  );
+}
+
+export type GetHubPoolClientParams = {
+  provider: providers.Provider;
+  logger: winston.Logger;
+  maxBlockLookBack: number;
+  chainId: number;
+  configStoreClient: across.clients.AcrossConfigStoreClient;
+  // dont usually need to include these
+  fromBlock?: number;
+  toBlock?: number;
+};
+
+export async function getHubPoolClient(params: GetHubPoolClientParams) {
+  const { provider, logger, maxBlockLookBack, chainId, configStoreClient } =
+    params;
+  const address = getDeployedAddress("HubPool", chainId);
+  const deployedBlockNumber = getDeployedBlockNumber("HubPool", chainId);
+
+  const hubPoolContract = new Contract(address, HubPoolFactory.abi, provider);
+  const fromBlock = params.fromBlock ?? deployedBlockNumber;
+  const toBlock = params.toBlock ?? (await provider.getBlockNumber());
+
+  const eventSearchConfig = {
+    fromBlock,
+    toBlock,
+    maxBlockLookBack,
+  };
+  logger.info({
+    message: "Initializing hubpool",
+    chainId,
+    ...eventSearchConfig,
+    blockRangeSearched: toBlock - fromBlock,
+  });
+  return new across.clients.HubPoolClient(
+    logger,
+    hubPoolContract,
+    configStoreClient,
+    deployedBlockNumber,
+    chainId,
+    eventSearchConfig,
+  );
+}
+
+export type RetryProviderConfig = {
+  providerCacheNamespace: string;
+  maxConcurrency: number;
+  pctRpcCallsLogged: number;
+  standardTtlBlockDistance: number;
+  noTtlBlockDistance: number;
+  providerCacheTtl: number;
+  nodeQuorumThreshold: number;
+  retries: number;
+  delay: number;
+};
+export type RetryProviderDeps = {
+  cache: across.interfaces.CachingMechanismInterface;
+  logger: winston.Logger;
+  providerUrl: string;
+  chainId: number;
+};
+export function getRetryProvider(
+  params: RetryProviderConfig & RetryProviderDeps,
+) {
+  return new across.providers.RetryProvider(
+    [[params.providerUrl, params.chainId]],
+    params.chainId,
+    params.nodeQuorumThreshold,
+    params.retries,
+    params.delay,
+    params.maxConcurrency,
+    params.providerCacheNamespace,
+    params.pctRpcCallsLogged,
+    params.cache,
+    params.standardTtlBlockDistance,
+    params.noTtlBlockDistance,
+    params.providerCacheTtl,
+    params.logger,
+  );
+}


### PR DESCRIPTION
# motivation
Add hubpool indexer with block range success status in the same way as previous spoke pool indexer.

# changes
This adds hubpoolindexer file which is basically a copy of the spoke pool indexer file but for hub events.  also adds similar config and startup routine as the spoke pool indexer

# todo
future prs will update spoke pool indexer to catch up with what was done in services/deposits.ts and deal with situations where redis and postres are not synced correctly