### PR TITLE
feat(bundle): include chain ids in proposed bundle events

### DIFF
--- a/packages/indexer-database/src/entities/evm/ProposedRootBundle.ts
+++ b/packages/indexer-database/src/entities/evm/ProposedRootBundle.ts
@@ -21,6 +21,9 @@ export class ProposedRootBundle {
   @Column({ type: "jsonb" })
   bundleEvaluationBlockNumbers: number[];
 
+  @Column({ type: "jsonb" })
+  chainIds: number[];
+
   @Column()
   poolRebalanceRoot: string;
 

--- a/packages/indexer-database/src/migrations/1726249543923-ProposedRootBundle.ts
+++ b/packages/indexer-database/src/migrations/1726249543923-ProposedRootBundle.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ProposedRootBundle1726249543923 implements MigrationInterface {
+  name = "ProposedRootBundle1726249543923";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."proposed_root_bundle" ADD "chainIds" jsonb NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."proposed_root_bundle" DROP COLUMN "chainIds"`,
+    );
+  }
+}

--- a/packages/indexer/src/services/hubPoolIndexer.ts
+++ b/packages/indexer/src/services/hubPoolIndexer.ts
@@ -164,7 +164,10 @@ export async function HubPoolIndexer(config: Config) {
 
     return {
       // we need to make sure we filter out all unecessary events for the block range requested
-      proposedRootBundleEvents,
+      proposedRootBundleEvents: proposedRootBundleEvents.map((p) => ({
+        ...p,
+        chainIds: configStoreClient.getChainIdIndicesForBlock(p.blockNumber),
+      })),
       rootBundleCanceledEvents,
       rootBundleDisputedEvents,
       rootBundleExecutedEvents: rootBundleExecutedEvents.filter(
@@ -174,7 +177,9 @@ export async function HubPoolIndexer(config: Config) {
     };
   }
   async function storeEvents(params: {
-    proposedRootBundleEvents: across.interfaces.ProposedRootBundle[];
+    proposedRootBundleEvents: (across.interfaces.ProposedRootBundle & {
+      chainIds: number[];
+    })[];
     rootBundleCanceledEvents: across.interfaces.CancelledRootBundle[];
     rootBundleDisputedEvents: across.interfaces.DisputedRootBundle[];
     rootBundleExecutedEvents: across.interfaces.ExecutedRootBundle[];


### PR DESCRIPTION
Adds an array of chain ids that represent the parallel array of `bundleEvaluationBlockNumbers`. The indices of both these columns are matched so `chainIds[0]` is the chain Id that represents the cutoff of `bundleEvaluationBlockNumbers[0]`