### PR TITLE
feat(bundles): add block range tracking

### DIFF
--- a/packages/indexer-database/src/entities/Bundle.ts
+++ b/packages/indexer-database/src/entities/Bundle.ts
@@ -4,6 +4,7 @@ import {
   JoinColumn,
   JoinTable,
   ManyToMany,
+  OneToMany,
   OneToOne,
   PrimaryGeneratedColumn,
 } from "typeorm";
@@ -11,6 +12,7 @@ import { ProposedRootBundle } from "./evm/ProposedRootBundle";
 import { RootBundleCanceled } from "./evm/RootBundleCanceled";
 import { RootBundleExecuted } from "./evm/RootBundleExecuted";
 import { RootBundleDisputed } from "./evm/RootBundleDisputed";
+import { BundleBlockRange } from "./BundleBlockRange";
 
 export enum BundleStatus {
   Proposed = "Proposed",
@@ -77,4 +79,9 @@ export class Bundle {
     },
   })
   executions: RootBundleExecuted[];
+
+  @OneToMany(() => BundleBlockRange, (range) => range.bundle, {
+    nullable: false,
+  })
+  ranges: BundleBlockRange[];
 }

--- a/packages/indexer-database/src/entities/BundleBlockRange.ts
+++ b/packages/indexer-database/src/entities/BundleBlockRange.ts
@@ -1,0 +1,30 @@
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from "typeorm";
+import { Bundle } from "./Bundle";
+
+@Entity()
+@Unique("UK_bundleBlockRange_bundleId_chainId", ["bundleId", "chainId"])
+export class BundleBlockRange {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Bundle, (bundle) => bundle.ranges, { nullable: false })
+  bundle: Bundle;
+
+  @Column({ nullable: false })
+  bundleId: number;
+
+  @Column({ nullable: false })
+  chainId: number;
+
+  @Column({ nullable: false })
+  startBlock: number;
+
+  @Column({ nullable: false })
+  endBlock: number;
+}

--- a/packages/indexer-database/src/entities/index.ts
+++ b/packages/indexer-database/src/entities/index.ts
@@ -14,4 +14,5 @@ export * from "./evm/TokensBridged";
 
 // Others
 export * from "./Bundle";
+export * from "./BundleBlockRange";
 export * from "./RelayHashInfo";

--- a/packages/indexer-database/src/main.ts
+++ b/packages/indexer-database/src/main.ts
@@ -37,6 +37,7 @@ export const createDataSource = (config: DatabaseConfig): DataSource => {
       entities.V3FundsDeposited,
       // Bundle
       entities.Bundle,
+      entities.BundleBlockRange,
       // Others
       entities.RelayHashInfo,
     ],

--- a/packages/indexer-database/src/migrations/1726523435568-BundleBlockRange.ts
+++ b/packages/indexer-database/src/migrations/1726523435568-BundleBlockRange.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class BundleBlockRange1726523435568 implements MigrationInterface {
+  name = "Bundle1726523435568";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "bundle_block_range" (
+            "id" SERIAL NOT NULL, 
+            "bundleId" integer NOT NULL, 
+            "chainId" integer NOT NULL, 
+            "startBlock" integer NOT NULL, 
+            "endBlock" integer NOT NULL, 
+            CONSTRAINT "UK_bundleBlockRange_bundleId_chainId" UNIQUE ("bundleId", "chainId"), 
+            CONSTRAINT "PK_903331c592ac44aaf237755fd8b" PRIMARY KEY ("id")
+        )`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "bundle_block_range" ADD CONSTRAINT "FK_f5c43af2e3e71193090d4f37285" FOREIGN KEY ("bundleId") REFERENCES "bundle"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "bundle_block_range" DROP CONSTRAINT "FK_f5c43af2e3e71193090d4f37285"`,
+    );
+    await queryRunner.query(`DROP TABLE "bundle_block_range"`);
+  }
+}

--- a/packages/indexer/src/database/BundleRepository.ts
+++ b/packages/indexer/src/database/BundleRepository.ts
@@ -109,6 +109,8 @@ export class BundleRepository extends utils.BaseRepository {
       .leftJoin("bundle_block_range", "br", "b.id = br.bundleId")
       .where("br.bundleId IS NULL")
       .select(["b.id", "proposal"])
+      .orderBy("proposal.blockNumber", "ASC")
+      .limit(1000) // Limit to 1000 bundles to process at a time
       .getMany();
   }
 
@@ -125,7 +127,7 @@ export class BundleRepository extends utils.BaseRepository {
     blockNumber: number,
     transactionIndex: number,
     logIndex: number,
-    maxLookbackFromBlock: number = Number.MAX_SAFE_INTEGER,
+    maxLookbackFromBlock: number = blockNumber, // Default to the entire range,
   ): Promise<entities.ProposedRootBundle | null> {
     return this.postgres
       .getRepository(entities.ProposedRootBundle)

--- a/packages/indexer/src/database/BundleRepository.ts
+++ b/packages/indexer/src/database/BundleRepository.ts
@@ -120,14 +120,14 @@ export class BundleRepository extends utils.BaseRepository {
    * @param blockNumber The block number to search from
    * @param transactionIndex The transaction index in the block to search from
    * @param logIndex The log index in the transaction to search from
-   * @param maxLookbackFromBlock The maximum number of blocks to look back from the provided block number
+   * @param maxLookbackFromBlock The maximum number of blocks to look back from the provided block number (optional)
    * @returns The closest proposed (undisputed/non-canceled) root bundle back in time, or undefined if none are found
    */
   public retrieveClosestProposedRootBundle(
     blockNumber: number,
     transactionIndex: number,
     logIndex: number,
-    maxLookbackFromBlock: number = blockNumber, // Default to the entire range,
+    maxLookbackFromBlock?: number,
   ): Promise<entities.ProposedRootBundle | null> {
     return this.postgres
       .getRepository(entities.ProposedRootBundle)
@@ -148,7 +148,11 @@ export class BundleRepository extends utils.BaseRepository {
           blockNumber,
           transactionIndex,
           logIndex,
-          blockDiff: blockNumber - maxLookbackFromBlock,
+          // If maxLookbackFromBlock is undefined, then allow the full range of blocks to be searched
+          blockDiff:
+            maxLookbackFromBlock !== undefined
+              ? blockNumber - maxLookbackFromBlock
+              : 0,
         },
       )
       .orderBy("prb.blockNumber", "DESC") // Grab the most recent proposal

--- a/packages/indexer/src/database/BundleRepository.ts
+++ b/packages/indexer/src/database/BundleRepository.ts
@@ -125,7 +125,7 @@ export class BundleRepository extends utils.BaseRepository {
     blockNumber: number,
     transactionIndex: number,
     logIndex: number,
-    maxLookbackFromBlock: number = 0,
+    maxLookbackFromBlock: number = Number.MAX_SAFE_INTEGER,
   ): Promise<entities.ProposedRootBundle | null> {
     return this.postgres
       .getRepository(entities.ProposedRootBundle)

--- a/packages/indexer/src/database/BundleRepository.ts
+++ b/packages/indexer/src/database/BundleRepository.ts
@@ -1,6 +1,12 @@
 import winston from "winston";
-import * as across from "@across-protocol/sdk";
 import { DataSource, entities, utils } from "@repo/indexer-database";
+
+export type BlockRangeInsertType = {
+  bundleId: number;
+  chainId: number;
+  startBlock: number;
+  endBlock: number;
+};
 
 /**
  * An abstraction class for interacting with the database for bundle-related operations.
@@ -93,6 +99,19 @@ export class BundleRepository extends utils.BaseRepository {
       .getMany();
   }
 
+  public retrieveBundlesWithoutBlockRangesDefined(): Promise<
+    Pick<entities.Bundle, "id" | "proposal">[]
+  > {
+    return this.postgres
+      .getRepository(entities.Bundle)
+      .createQueryBuilder("b")
+      .leftJoinAndSelect("b.proposal", "proposal")
+      .leftJoin("bundle_block_range", "br", "b.id = br.bundleId")
+      .where("br.bundleId IS NULL")
+      .select(["b.id", "proposal"])
+      .getMany();
+  }
+
   /**
    * Retrieves the closest proposed root bundle to the given block number, transaction index, and log index. The
    * proposed root bundle can be no further back than the given max lookback from the provided block number.
@@ -100,20 +119,18 @@ export class BundleRepository extends utils.BaseRepository {
    * @param transactionIndex The transaction index in the block to search from
    * @param logIndex The log index in the transaction to search from
    * @param maxLookbackFromBlock The maximum number of blocks to look back from the provided block number
-   * @returns The closest proposed root bundle back in time, or undefined if none are found
+   * @returns The closest proposed (undisputed/non-canceled) root bundle back in time, or undefined if none are found
    */
   public retrieveClosestProposedRootBundle(
     blockNumber: number,
     transactionIndex: number,
     logIndex: number,
-    maxLookbackFromBlock: number,
-  ): Promise<Pick<entities.ProposedRootBundle, "id"> | null> {
-    const proposedRootBundleRepository = this.postgres.getRepository(
-      entities.ProposedRootBundle,
-    );
-    return proposedRootBundleRepository
+    maxLookbackFromBlock: number = 0,
+  ): Promise<entities.ProposedRootBundle | null> {
+    return this.postgres
+      .getRepository(entities.ProposedRootBundle)
       .createQueryBuilder("prb")
-      .select(["prb.id"])
+      .leftJoin(entities.Bundle, "b", "b.proposalId = prb.id")
       .where(
         // Proposal is in the past
         "(prb.blockNumber < :blockNumber OR " +
@@ -122,7 +139,9 @@ export class BundleRepository extends utils.BaseRepository {
           // Proposal happened earlier in the same transaction
           "(prb.blockNumber = :blockNumber AND prb.transactionIndex = :transactionIndex AND prb.logIndex < :logIndex)) AND " +
           // Ensure the block difference is less than an average bundle length in ETH blocks
-          "prb.blockNumber > :blockDiff",
+          "prb.blockNumber > :blockDiff AND" +
+          // The bundle hasn't been disputed or canceled. This is a valid bundle to execute.
+          "(b.disputeId IS NULL AND b.cancelationId IS NULL)",
         {
           blockNumber,
           transactionIndex,
@@ -200,5 +219,14 @@ export class BundleRepository extends utils.BaseRepository {
       }),
     );
     return results.filter((x) => x).length;
+  }
+
+  public associateBlockRangeWithBundle(ranges: BlockRangeInsertType[]) {
+    return this.postgres
+      .getRepository(entities.BundleBlockRange)
+      .createQueryBuilder()
+      .insert()
+      .values(ranges)
+      .execute();
   }
 }

--- a/packages/indexer/src/services/bundles.ts
+++ b/packages/indexer/src/services/bundles.ts
@@ -7,10 +7,10 @@ import {
   BundleRepository,
 } from "../database/BundleRepository";
 
-const AVERAGE_BUNDLE_LIVENESS_SECONDS = 60 * 60; // 1 hour
+const BUNDLE_LIVENESS_SECONDS = 4 * 60 * 60; // 4 hour
 const AVERAGE_SECONDS_PER_BLOCK = 13; // 13 seconds per block on ETH
-const AVERAGE_BLOCKS_PER_BUNDLE = Math.floor(
-  AVERAGE_BUNDLE_LIVENESS_SECONDS / AVERAGE_SECONDS_PER_BLOCK,
+const BLOCKS_PER_BUNDLE = Math.floor(
+  BUNDLE_LIVENESS_SECONDS / AVERAGE_SECONDS_PER_BLOCK,
 );
 
 type BundleConfig = {
@@ -77,7 +77,7 @@ function logResultOfAssignment(
   if (unassociatedRecordsCount > 0) {
     logger.info({
       at: `Bundles#assignToBundle`,
-      message: "Found and associated proposed events with bundles",
+      message: "Found and associated events with bundles",
       unassociatedRecordsCount,
       persistedRecordsCount,
       eventType,
@@ -105,7 +105,7 @@ async function assignDisputeEventToBundle(
             blockNumber,
             transactionIndex,
             logIndex,
-            AVERAGE_BLOCKS_PER_BUNDLE,
+            BLOCKS_PER_BUNDLE,
           );
         if (!proposedBundle) {
           return undefined;
@@ -148,7 +148,7 @@ async function assignCanceledEventToBundle(
             blockNumber,
             transactionIndex,
             logIndex,
-            AVERAGE_BLOCKS_PER_BUNDLE,
+            BLOCKS_PER_BUNDLE,
           );
         if (!proposedBundle) {
           return undefined;

--- a/packages/indexer/src/services/bundles.ts
+++ b/packages/indexer/src/services/bundles.ts
@@ -182,7 +182,6 @@ async function assignBundleRangesToProposal(
   const [unassociatedDisputes, unassociatedCancellations] = await Promise.all([
     dbRepository.retrieveUnassociatedDisputedEvents(),
     dbRepository.retrieveUnassociatedCanceledEvents(),
-    dbRepository.retrieveUnassociatedProposedRootBundleEvents(),
   ]);
   if (unassociatedDisputes.length > 0 || unassociatedCancellations.length > 0) {
     logger.info({


### PR DESCRIPTION
We should track start/end block ranges into their own entity so that resolving a bundles range requires a single lookup.