### PR TITLE
Fix: Migration execution not found

### DIFF
--- a/docker/migrations.command.sh
+++ b/docker/migrations.command.sh
@@ -5,5 +5,5 @@
 #   1. Change directory to `packages/indexer-database`
 #   2. Run the migration files using the `db:migration:run` script
 # Note: this operation is idempotent, so it can be run multiple times without any issues
-cd ./packages/indexer-database
+cd ../packages/indexer-database
 npm run db:migration:run


### PR DESCRIPTION
fixing the issue
```
./docker/migrations.command.sh: cd: line 8: can't cd to ./packages/indexer-database: No such file or directory
npm error Missing script: "db:migration:run"
```