### PR TITLE
fix: migrations issue

### DIFF
--- a/packages/indexer-database/src/entities/RootBundleExecutedJoinTable.ts
+++ b/packages/indexer-database/src/entities/RootBundleExecutedJoinTable.ts
@@ -1,6 +1,6 @@
 import { Entity, PrimaryColumn } from "typeorm";
 
-@Entity("bundle_executions", {synchronize: false})
+@Entity("bundle_executions", { synchronize: false })
 export class RootBundleExecutedJoinTable {
   @PrimaryColumn()
   bundleId: number;

--- a/packages/indexer-database/src/entities/RootBundleExecutedJoinTable.ts
+++ b/packages/indexer-database/src/entities/RootBundleExecutedJoinTable.ts
@@ -1,6 +1,6 @@
 import { Entity, PrimaryColumn } from "typeorm";
 
-@Entity("bundle_executions")
+@Entity("bundle_executions", {synchronize: false})
 export class RootBundleExecutedJoinTable {
   @PrimaryColumn()
   bundleId: number;


### PR DESCRIPTION
Migrations dropping and recreating foreign keys for "bundle_executions" table are being created every time we generate migrations. This was happening because typeorm is keeping track of this table from two entities (Bundle and RootBundleExecutedJoinTable).
