### PR TITLE
nit: remove unused variable

### DIFF
--- a/packages/indexer/src/main.ts
+++ b/packages/indexer/src/main.ts
@@ -109,7 +109,7 @@ export async function Main(config: parseEnv.Config, logger: winston.Logger) {
     at: "Indexer#Main",
   });
   // start all indexers in parallel, will wait for them to complete, but they all loop independently
-  const [bundleResults, hubPoolResult, ...spokeResults] =
+  const [bundleResults, ...spokeResults] =
     await Promise.allSettled([
       bundleProcessor.start(10),
       ...spokePoolIndexers.map((s) => s.start(10)),


### PR DESCRIPTION
`hubPoolResult` is not used.