### PR TITLE
fix(bundleProccesor): executed status query

### DIFF
--- a/packages/indexer/src/database/BundleRepository.ts
+++ b/packages/indexer/src/database/BundleRepository.ts
@@ -325,7 +325,7 @@ export class BundleRepository extends utils.BaseRepository {
 
     const leafCountSubquery = `(SELECT proposal."poolRebalanceLeafCount"
       FROM "evm"."proposed_root_bundle" proposal
-      WHERE proposal.id = bundle."proposalId"
+      WHERE proposal."id" = bundle."proposalId"
       LIMIT 1)`;
 
     const executedUpdateQuery = bundleRepo

--- a/packages/indexer/src/services/bundles.ts
+++ b/packages/indexer/src/services/bundles.ts
@@ -43,7 +43,7 @@ export class Processor extends BaseIndexer {
     await assignCanceledEventToBundle(bundleRepository, logger);
     await assignBundleRangesToProposal(bundleRepository, logger);
     await assignExecutionsToBundle(bundleRepository, logger);
-    await assignBundleValidatedStatus(bundleRepository, logger);
+    await assignBundleExecutedStatus(bundleRepository, logger);
   }
 
   protected async initialize(): Promise<void> {
@@ -327,14 +327,14 @@ async function assignBundleToProposedEvent(
  * @param logger A logger instance
  * @returns A void promise
  */
-async function assignBundleValidatedStatus(
+async function assignBundleExecutedStatus(
   dbRepository: BundleRepository,
   logger: winston.Logger,
 ): Promise<void> {
   const updateCount = await dbRepository.updateBundleExecutedStatus();
   if (updateCount) {
     logger.info({
-      at: "Bundles#assignBundleValidatedStatus",
+      at: "Bundles#assignBundleExecutedStatus",
       message: "Updated bundles with executed status",
       bundlesUpdatedWithExecutedStatus: updateCount,
     });


### PR DESCRIPTION
The `Executed` status of Bundles was not being set because when executing the following query Typeorm was converting `proposal.id` to `proposalId`.
```
const leafCountSubquery = `(SELECT proposal."poolRebalanceLeafCount"
      FROM "evm"."proposed_root_bundle" proposal
      WHERE proposal.id = bundle."proposalId"
      LIMIT 1)`;
```
