### PR TITLE
fix: set from block when updating sdk clients

### DIFF
--- a/packages/indexer/src/services/HubPoolIndexerDataHandler.ts
+++ b/packages/indexer/src/services/HubPoolIndexerDataHandler.ts
@@ -96,9 +96,10 @@ export class HubPoolIndexerDataHandler implements IndexerDataHandler {
   ): Promise<FetchEventsResult> {
     const { hubPoolClient, configStoreClient } = this;
 
+    hubPoolClient.firstBlockToSearch = blockRange.from;
     configStoreClient.eventSearchConfig.toBlock = blockRange.to;
-    hubPoolClient.eventSearchConfig.fromBlock = blockRange.from;
     hubPoolClient.eventSearchConfig.toBlock = blockRange.to;
+
     await configStoreClient.update();
     await hubPoolClient.update();
     const proposedRootBundleEvents =

--- a/packages/indexer/src/services/SpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/services/SpokePoolIndexerDataHandler.ts
@@ -104,6 +104,7 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
   ): Promise<FetchEventsResult> {
     const { configStoreClient, hubPoolClient, spokePoolClient } = this;
 
+    spokePoolClient.firstBlockToSearch = blockRange.from;
     spokePoolClient.eventSearchConfig.toBlock = blockRange.to;
 
     await configStoreClient.update();


### PR DESCRIPTION
When setting the `from` block in the SDK contract clients, `firstBlockToSearch` is the correct property to set, not `eventSearchConfig.fromBlock`