### PR TITLE
fix(bundles): fix range start block and bundle id when assigning events

### DIFF
--- a/packages/indexer-database/src/entities/Bundle.ts
+++ b/packages/indexer-database/src/entities/Bundle.ts
@@ -35,7 +35,9 @@ export class Bundle {
   @Column()
   slowRelayRoot: string;
 
-  @OneToOne(() => ProposedRootBundle, { nullable: false })
+  @OneToOne(() => ProposedRootBundle, (proposal) => proposal.bundle, {
+    nullable: false,
+  })
   @JoinColumn({
     foreignKeyConstraintName: "FK_bundle_rootBundleProposeId",
   })
@@ -44,7 +46,9 @@ export class Bundle {
   @Column({ nullable: false })
   proposalId: number;
 
-  @OneToOne(() => RootBundleCanceled, { nullable: true })
+  @OneToOne(() => RootBundleCanceled, (cancelation) => cancelation.bundle, {
+    nullable: true,
+  })
   @JoinColumn({
     foreignKeyConstraintName: "FK_bundle_rootBundleCanceledId",
   })
@@ -53,7 +57,9 @@ export class Bundle {
   @Column({ nullable: true })
   cancelationId: number;
 
-  @OneToOne(() => RootBundleDisputed, { nullable: true })
+  @OneToOne(() => RootBundleDisputed, (dispute) => dispute.bundle, {
+    nullable: true,
+  })
   @JoinColumn({
     foreignKeyConstraintName: "FK_bundle_rootBundleDisputedId",
   })

--- a/packages/indexer-database/src/entities/evm/ProposedRootBundle.ts
+++ b/packages/indexer-database/src/entities/evm/ProposedRootBundle.ts
@@ -2,9 +2,11 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToOne,
   PrimaryGeneratedColumn,
   Unique,
 } from "typeorm";
+import { Bundle } from "../Bundle";
 
 @Entity({ schema: "evm" })
 @Unique("UK_proposedRootBundle_txHash", ["transactionHash"])
@@ -35,6 +37,9 @@ export class ProposedRootBundle {
 
   @Column()
   proposer: string;
+
+  @OneToOne(() => Bundle, (bundle) => bundle.proposal)
+  bundle: Bundle;
 
   @Column()
   transactionHash: string;

--- a/packages/indexer-database/src/entities/evm/RootBundleCanceled.ts
+++ b/packages/indexer-database/src/entities/evm/RootBundleCanceled.ts
@@ -2,9 +2,11 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToOne,
   PrimaryGeneratedColumn,
   Unique,
 } from "typeorm";
+import { Bundle } from "../Bundle";
 
 @Entity({ schema: "evm" })
 @Unique("UK_rootBundleCanceled_txHash", ["transactionHash"])
@@ -17,6 +19,9 @@ export class RootBundleCanceled {
 
   @Column()
   requestTime: Date;
+
+  @OneToOne(() => Bundle, (bundle) => bundle.cancelation)
+  bundle: Bundle;
 
   @Column()
   transactionHash: string;

--- a/packages/indexer-database/src/entities/evm/RootBundleDisputed.ts
+++ b/packages/indexer-database/src/entities/evm/RootBundleDisputed.ts
@@ -2,9 +2,11 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToOne,
   PrimaryGeneratedColumn,
   Unique,
 } from "typeorm";
+import { Bundle } from "../Bundle";
 
 @Entity({ schema: "evm" })
 @Unique("UK_rootBundleDisputed_txHash", ["transactionHash"])
@@ -17,6 +19,9 @@ export class RootBundleDisputed {
 
   @Column()
   requestTime: Date;
+
+  @OneToOne(() => Bundle, (bundle) => bundle.dispute)
+  bundle: Bundle;
 
   @Column()
   transactionHash: string;

--- a/packages/indexer/src/database/BundleRepository.ts
+++ b/packages/indexer/src/database/BundleRepository.ts
@@ -48,14 +48,14 @@ export class BundleRepository extends utils.BaseRepository {
     );
     // Find all canceled events that haven't been associated with a bundle.
     return canceledRootBundleRepository
-      .createQueryBuilder("drb")
+      .createQueryBuilder("crb")
       .select([
-        "drb.id",
-        "drb.blockNumber",
-        "drb.logIndex",
-        "drb.transactionIndex",
+        "crb.id",
+        "crb.blockNumber",
+        "crb.logIndex",
+        "crb.transactionIndex",
       ])
-      .leftJoin("bundle", "b", "b.cancelationId = drb.id")
+      .leftJoin("crb.bundle", "b")
       .where("b.cancelationId IS NULL")
       .getMany();
   }
@@ -80,7 +80,7 @@ export class BundleRepository extends utils.BaseRepository {
         "drb.logIndex",
         "drb.transactionIndex",
       ])
-      .leftJoin("bundle", "b", "b.disputeId = drb.id")
+      .leftJoin("drb.bundle", "b")
       .where("b.disputeId IS NULL")
       .getMany();
   }
@@ -108,7 +108,7 @@ export class BundleRepository extends utils.BaseRepository {
         "prb.relayerRefundRoot",
         "prb.slowRelayRoot",
       ])
-      .leftJoin("bundle", "b", "b.proposalId = prb.id")
+      .leftJoin("prb.bundle", "b")
       .where("b.proposalId IS NULL")
       .getMany();
   }
@@ -177,7 +177,7 @@ export class BundleRepository extends utils.BaseRepository {
     return this.postgres
       .getRepository(entities.ProposedRootBundle)
       .createQueryBuilder("prb")
-      .leftJoin(entities.Bundle, "b", "b.proposalId = prb.id")
+      .leftJoinAndSelect("prb.bundle", "b")
       .where(
         // Proposal is in the past
         "(prb.blockNumber < :blockNumber OR " +


### PR DESCRIPTION
This PR fixes two issues related to bundles:
- When saving the bundle range, we were not incrementing the start block so the end block of each bundle was being repeated as the start block of the next bundle.
- When relating events to bundles, we were assuming that the bundle id was equal to the id of the proposal, but that might not be true in some cases.