### PR TITLE
fix: temporarily reduce the size of the block range

### DIFF
--- a/packages/indexer/src/data-indexing/service/Indexer.ts
+++ b/packages/indexer/src/data-indexing/service/Indexer.ts
@@ -98,7 +98,7 @@ export class Indexer {
       ? lastBlockFinalisedStored + 1
       : this.dataHandler.getStartIndexingBlockNumber();
     // TODO: hardcoded 200_000, should be a config or removed
-    const toBlock = Math.min(fromBlock + 200_000, latestBlockNumber);
+    const toBlock = Math.min(fromBlock + 50_000, latestBlockNumber);
     const blockRange: BlockRange = { from: fromBlock, to: toBlock };
     const lastFinalisedBlockInBlockRange = Math.min(
       blockRange.to,


### PR DESCRIPTION
Because of the logic for getting the integrator id, we make many getTransactionHash calls (thousands per block range) which are taking a long time. Ideally the integrator id should be computed using the Redis queues.