### PR TITLE
fix: remove the logic for deleting removed events

### DIFF
--- a/packages/indexer-database/src/utils/BaseRepository.ts
+++ b/packages/indexer-database/src/utils/BaseRepository.ts
@@ -56,12 +56,6 @@ export class BaseRepository {
       .orUpdate(Object.keys(data[0] as any), uniqueKeysAsStrings)
       .returning("*")
       .execute();
-    await repository
-      .createQueryBuilder()
-      .delete()
-      .where("finalised = false")
-      .andWhere("blockNumber <= :lastFinalisedBlock", { lastFinalisedBlock })
-      .execute();
 
     return savedData.generatedMaps as Entity[];
   }


### PR DESCRIPTION
This query was meant to delete events that were removed due to a re-org, but the query is wrong and it deletes more data than it should