### PR TITLE
fix: slow fills insertion

### DIFF
--- a/packages/indexer-database/src/entities/evm/RequestedV3SlowFill.ts
+++ b/packages/indexer-database/src/entities/evm/RequestedV3SlowFill.ts
@@ -25,12 +25,6 @@ export class RequestedV3SlowFill {
   destinationChainId: number;
 
   @Column()
-  fromLiteChain: boolean;
-
-  @Column()
-  toLiteChain: boolean;
-
-  @Column()
   depositor: string;
 
   @Column()

--- a/packages/indexer-database/src/migrations/1729701068951-SlowFillV3.ts
+++ b/packages/indexer-database/src/migrations/1729701068951-SlowFillV3.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class SlowFillV31729701068951 implements MigrationInterface {
+  name = "SlowFillV31729701068951";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."requested_v3_slow_fill" DROP COLUMN "fromLiteChain"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."requested_v3_slow_fill" DROP COLUMN "toLiteChain"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."requested_v3_slow_fill" ADD "toLiteChain" boolean NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."requested_v3_slow_fill" ADD "fromLiteChain" boolean NOT NULL`,
+    );
+  }
+}

--- a/packages/indexer/src/database/SpokePoolRepository.ts
+++ b/packages/indexer/src/database/SpokePoolRepository.ts
@@ -115,7 +115,7 @@ export class SpokePoolRepository extends utils.BaseRepository {
         this.insertWithFinalisationCheck(
           entities.RequestedV3SlowFill,
           eventsChunk,
-          ["depositId", "originChainId"],
+          ["relayHash"],
           lastFinalisedBlock,
         ),
       ),


### PR DESCRIPTION
- Deleting `fromLiteChain` and `toLiteChain` columns from `requestedV3SlowFill` table as they are not populated for slow fills by the SpokePool clients.
- Changing the unique keys we are using when inserting slow fills with finalisation check as they have to match the unique constraint of the table.