### PR TITLE
fix: speedup unique constraint

### DIFF
--- a/packages/indexer-database/src/entities/evm/RequestedSpeedUpV3Deposit.ts
+++ b/packages/indexer-database/src/entities/evm/RequestedSpeedUpV3Deposit.ts
@@ -7,10 +7,11 @@ import {
 } from "typeorm";
 
 @Entity({ schema: "evm" })
-@Unique("UK_requestedSpeedUpV3_depositId_originChain_txHash", [
+@Unique("UK_speedUpV3_depositId_originChain_txHash_logIdx", [
   "depositId",
   "originChainId",
   "transactionHash",
+  "logIndex",
 ])
 export class RequestedSpeedUpV3Deposit {
   @PrimaryGeneratedColumn()

--- a/packages/indexer-database/src/migrations/1729700385983-SpeedUpV3.ts
+++ b/packages/indexer-database/src/migrations/1729700385983-SpeedUpV3.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class SpeedUpV31729700385983 implements MigrationInterface {
+  name = "SpeedUpV31729700385983";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."requested_speed_up_v3_deposit" DROP CONSTRAINT "UK_requestedSpeedUpV3_depositId_originChain_txHash"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."requested_speed_up_v3_deposit" ADD CONSTRAINT "UK_speedUpV3_depositId_originChain_txHash_logIdx" UNIQUE ("depositId", "originChainId", "transactionHash", "logIndex")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."requested_speed_up_v3_deposit" DROP CONSTRAINT "UK_speedUpV3_depositId_originChain_txHash_logIdx"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."requested_speed_up_v3_deposit" ADD CONSTRAINT "UK_requestedSpeedUpV3_depositId_originChain_txHash" UNIQUE ("originChainId", "depositId", "transactionHash")`,
+    );
+  }
+}

--- a/packages/indexer/src/database/SpokePoolRepository.ts
+++ b/packages/indexer/src/database/SpokePoolRepository.ts
@@ -149,7 +149,7 @@ export class SpokePoolRepository extends utils.BaseRepository {
         this.insertWithFinalisationCheck(
           entities.RequestedSpeedUpV3Deposit,
           eventsChunk,
-          ["depositId", "originChainId", "transactionHash"],
+          ["depositId", "originChainId", "transactionHash", "logIndex"],
           lastFinalisedBlock,
         ),
       ),


### PR DESCRIPTION
Adding logIndex to speedup's unique constraint as there can be more than 1 event in the same transaction. See for example: https://optimistic.etherscan.io/tx/0x2b02e3132f2dba66c675be4a75de2cda2d32dea75a80123ff348d752933793d8#eventlog