### PR TITLE
fix: replace bulk upserts with inserts/updates if needed

### DIFF
--- a/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
+++ b/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
@@ -70,7 +70,7 @@ export class V3FundsDeposited {
   quoteBlockNumber: number;
 
   @Column({ nullable: true })
-  integratorId: string;
+  integratorId?: string;
 
   @Column()
   transactionHash: string;

--- a/packages/indexer-database/src/index.ts
+++ b/packages/indexer-database/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./main";
 export * as entities from "./entities";
 export * as utils from "./utils";
+export * from "./model";

--- a/packages/indexer-database/src/main.ts
+++ b/packages/indexer-database/src/main.ts
@@ -1,15 +1,9 @@
 import "reflect-metadata";
 import { DataSource, LessThan, Not, In } from "typeorm";
 import * as entities from "./entities";
+import { DatabaseConfig } from "./model";
 
 export { DataSource, LessThan, Not, In };
-export type DatabaseConfig = {
-  host: string;
-  port: string;
-  user: string;
-  password: string;
-  dbName: string;
-};
 
 export const createDataSource = (config: DatabaseConfig): DataSource => {
   return new DataSource({

--- a/packages/indexer-database/src/model/index.ts
+++ b/packages/indexer-database/src/model/index.ts
@@ -1,0 +1,28 @@
+export type DatabaseConfig = {
+  host: string;
+  port: string;
+  user: string;
+  password: string;
+  dbName: string;
+};
+
+/**
+ * Enum to represent the result type of a query.
+ * - If the entity is identical to the one in the database, return `Nothing`.
+ * - If the unique keys are not present, return Inserted.
+ * - If the finalised field was the only one that changed, return `Finalised`.
+ * - If any of the entity fields were changed, return Updated.
+ * - If both the finalised field and other fields were changed, return UpdatedAndFinalised.
+ */
+export enum SaveQueryResultType {
+  Nothing = "nothing",
+  Inserted = "inserted",
+  Finalised = "finalised",
+  Updated = "updated",
+  UpdatedAndFinalised = "updatedAndFinalised",
+}
+
+export type SaveQueryResult<T> = {
+  data: T | undefined;
+  result: SaveQueryResultType;
+};

--- a/packages/indexer-database/src/utils/BaseRepository.ts
+++ b/packages/indexer-database/src/utils/BaseRepository.ts
@@ -1,18 +1,6 @@
 import { DataSource, EntityTarget, ObjectLiteral } from "typeorm";
 import winston from "winston";
 
-import { SaveQueryResultType, SaveQueryResult } from "../model";
-
-export function filterSaveQueryResults<Entity extends ObjectLiteral>(
-  results: SaveQueryResult<Entity>[],
-  type: SaveQueryResultType,
-) {
-  return results
-    .filter((result) => result.result === type)
-    .map((result) => result.data)
-    .filter((data) => data !== undefined);
-}
-
 export class BaseRepository {
   constructor(
     protected postgres: DataSource,
@@ -70,105 +58,5 @@ export class BaseRepository {
       .execute();
 
     return savedData.generatedMaps as Entity[];
-  }
-
-  /**
-   * Saves the entities to the database.
-   * @param entity - The entity to save.
-   * @param data - The data to save.
-   * @param uniqueKeys
-   * The unique keys to check for. It is recommended these keys to be indexed columns, so that the query is faster.
-   * @param comparisonKeys - The keys to compare for changes.
-   */
-  protected async saveAndHandleFinalisationBatch<Entity extends ObjectLiteral>(
-    entity: EntityTarget<Entity>,
-    data: Partial<Entity>[],
-    uniqueKeys: (keyof Entity)[],
-    comparisonKeys: (keyof Entity)[],
-  ): Promise<SaveQueryResult<Entity>[]> {
-    return Promise.all(
-      data.map((dataItem) =>
-        this.saveAndHandleFinalisation(
-          entity,
-          dataItem,
-          uniqueKeys,
-          comparisonKeys,
-        ),
-      ),
-    );
-  }
-
-  /**
-   * Saves the entity to the database.
-   * @param entity - The entity to save.
-   * @param data - The data to save.
-   * @param uniqueKeys
-   * The unique keys to check for. It is recommended these keys to be indexed columns, so that the query is faster.
-   * @param comparisonKeys - The keys to compare for changes.
-   */
-  protected async saveAndHandleFinalisation<Entity extends ObjectLiteral>(
-    entity: EntityTarget<Entity>,
-    data: Partial<Entity>,
-    uniqueKeys: (keyof Entity)[],
-    comparisonKeys: (keyof Entity)[],
-  ): Promise<SaveQueryResult<Entity>> {
-    const where = uniqueKeys.reduce(
-      (acc, key) => {
-        acc[key] = data[key];
-        return acc;
-      },
-      {} as Record<keyof Entity, any>,
-    );
-    const dbEntity = await this.postgres
-      .getRepository(entity)
-      .findOne({ where });
-
-    if (!dbEntity) {
-      await this.postgres.getRepository(entity).insert(data);
-      return {
-        data: (await this.postgres
-          .getRepository(entity)
-          .findOne({ where })) as Entity,
-        result: SaveQueryResultType.Inserted,
-      };
-    }
-
-    // Check if the any of values of the comparison keys have changed
-    const isChanged = comparisonKeys.some((key) => data[key] !== dbEntity[key]);
-    // Check if the data moved in finalised state
-    const isFinalisedChanged = data.finalised && !dbEntity.finalised;
-
-    if (isChanged) {
-      await this.postgres.getRepository(entity).update(where, data);
-      if (isFinalisedChanged) {
-        return {
-          data: (await this.postgres
-            .getRepository(entity)
-            .findOne({ where })) as Entity,
-          result: SaveQueryResultType.UpdatedAndFinalised,
-        };
-      }
-      return {
-        data: (await this.postgres
-          .getRepository(entity)
-          .findOne({ where })) as Entity,
-        result: SaveQueryResultType.Updated,
-      };
-    }
-
-    if (isFinalisedChanged) {
-      await this.postgres.getRepository(entity).update(where, data);
-      return {
-        data: (await this.postgres
-          .getRepository(entity)
-          .findOne({ where })) as Entity,
-        result: SaveQueryResultType.Finalised,
-      };
-    }
-
-    return {
-      data: undefined,
-      result: SaveQueryResultType.Nothing,
-    };
   }
 }

--- a/packages/indexer-database/src/utils/BaseRepository.ts
+++ b/packages/indexer-database/src/utils/BaseRepository.ts
@@ -1,6 +1,18 @@
 import { DataSource, EntityTarget, ObjectLiteral } from "typeorm";
 import winston from "winston";
 
+import { SaveQueryResultType, SaveQueryResult } from "../model";
+
+export function filterSaveQueryResults<Entity extends ObjectLiteral>(
+  results: SaveQueryResult<Entity>[],
+  type: SaveQueryResultType,
+) {
+  return results
+    .filter((result) => result.result === type)
+    .map((result) => result.data)
+    .filter((data) => data !== undefined);
+}
+
 export class BaseRepository {
   constructor(
     protected postgres: DataSource,
@@ -58,5 +70,105 @@ export class BaseRepository {
       .execute();
 
     return savedData.generatedMaps as Entity[];
+  }
+
+  /**
+   * Saves the entities to the database.
+   * @param entity - The entity to save.
+   * @param data - The data to save.
+   * @param uniqueKeys
+   * The unique keys to check for. It is recommended these keys to be indexed columns, so that the query is faster.
+   * @param comparisonKeys - The keys to compare for changes.
+   */
+  protected async saveAndHandleFinalisationBatch<Entity extends ObjectLiteral>(
+    entity: EntityTarget<Entity>,
+    data: Partial<Entity>[],
+    uniqueKeys: (keyof Entity)[],
+    comparisonKeys: (keyof Entity)[],
+  ): Promise<SaveQueryResult<Entity>[]> {
+    return Promise.all(
+      data.map((dataItem) =>
+        this.saveAndHandleFinalisation(
+          entity,
+          dataItem,
+          uniqueKeys,
+          comparisonKeys,
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Saves the entity to the database.
+   * @param entity - The entity to save.
+   * @param data - The data to save.
+   * @param uniqueKeys
+   * The unique keys to check for. It is recommended these keys to be indexed columns, so that the query is faster.
+   * @param comparisonKeys - The keys to compare for changes.
+   */
+  protected async saveAndHandleFinalisation<Entity extends ObjectLiteral>(
+    entity: EntityTarget<Entity>,
+    data: Partial<Entity>,
+    uniqueKeys: (keyof Entity)[],
+    comparisonKeys: (keyof Entity)[],
+  ): Promise<SaveQueryResult<Entity>> {
+    const where = uniqueKeys.reduce(
+      (acc, key) => {
+        acc[key] = data[key];
+        return acc;
+      },
+      {} as Record<keyof Entity, any>,
+    );
+    const dbEntity = await this.postgres
+      .getRepository(entity)
+      .findOne({ where });
+
+    if (!dbEntity) {
+      await this.postgres.getRepository(entity).insert(data);
+      return {
+        data: (await this.postgres
+          .getRepository(entity)
+          .findOne({ where })) as Entity,
+        result: SaveQueryResultType.Inserted,
+      };
+    }
+
+    // Check if the any of values of the comparison keys have changed
+    const isChanged = comparisonKeys.some((key) => data[key] !== dbEntity[key]);
+    // Check if the data moved in finalised state
+    const isFinalisedChanged = data.finalised && !dbEntity.finalised;
+
+    if (isChanged) {
+      await this.postgres.getRepository(entity).update(where, data);
+      if (isFinalisedChanged) {
+        return {
+          data: (await this.postgres
+            .getRepository(entity)
+            .findOne({ where })) as Entity,
+          result: SaveQueryResultType.UpdatedAndFinalised,
+        };
+      }
+      return {
+        data: (await this.postgres
+          .getRepository(entity)
+          .findOne({ where })) as Entity,
+        result: SaveQueryResultType.Updated,
+      };
+    }
+
+    if (isFinalisedChanged) {
+      await this.postgres.getRepository(entity).update(where, data);
+      return {
+        data: (await this.postgres
+          .getRepository(entity)
+          .findOne({ where })) as Entity,
+        result: SaveQueryResultType.Finalised,
+      };
+    }
+
+    return {
+      data: undefined,
+      result: SaveQueryResultType.Nothing,
+    };
   }
 }

--- a/packages/indexer-database/src/utils/BlockchainEventRepository.ts
+++ b/packages/indexer-database/src/utils/BlockchainEventRepository.ts
@@ -1,0 +1,121 @@
+import { DataSource, EntityTarget, ObjectLiteral } from "typeorm";
+import winston from "winston";
+
+import { SaveQueryResultType, SaveQueryResult } from "../model";
+
+export function filterSaveQueryResults<Entity extends ObjectLiteral>(
+  results: SaveQueryResult<Entity>[],
+  type: SaveQueryResultType,
+) {
+  return results
+    .filter((result) => result.result === type)
+    .map((result) => result.data)
+    .filter((data) => data !== undefined);
+}
+
+export class BlockchainEventRepository {
+  constructor(
+    protected postgres: DataSource,
+    protected logger: winston.Logger,
+  ) {}
+
+  /**
+   * Saves the entities to the database.
+   * @param entity - The entity to save.
+   * @param data - The data to save.
+   * @param uniqueKeys
+   * The unique keys to check for. It is recommended these keys to be indexed columns, so that the query is faster.
+   * @param comparisonKeys - The keys to compare for changes.
+   */
+  protected async saveAndHandleFinalisationBatch<Entity extends ObjectLiteral>(
+    entity: EntityTarget<Entity>,
+    data: Partial<Entity>[],
+    uniqueKeys: (keyof Entity)[],
+    comparisonKeys: (keyof Entity)[],
+  ): Promise<SaveQueryResult<Entity>[]> {
+    return Promise.all(
+      data.map((dataItem) =>
+        this.saveAndHandleFinalisation(
+          entity,
+          dataItem,
+          uniqueKeys,
+          comparisonKeys,
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Saves the entity to the database.
+   * @param entity - The entity to save.
+   * @param data - The data to save.
+   * @param uniqueKeys
+   * The unique keys to check for. It is recommended these keys to be indexed columns, so that the query is faster.
+   * @param comparisonKeys - The keys to compare for changes.
+   */
+  protected async saveAndHandleFinalisation<Entity extends ObjectLiteral>(
+    entity: EntityTarget<Entity>,
+    data: Partial<Entity>,
+    uniqueKeys: (keyof Entity)[],
+    comparisonKeys: (keyof Entity)[],
+  ): Promise<SaveQueryResult<Entity>> {
+    const where = uniqueKeys.reduce(
+      (acc, key) => {
+        acc[key] = data[key];
+        return acc;
+      },
+      {} as Record<keyof Entity, any>,
+    );
+    const dbEntity = await this.postgres
+      .getRepository(entity)
+      .findOne({ where });
+
+    if (!dbEntity) {
+      await this.postgres.getRepository(entity).insert(data);
+      return {
+        data: (await this.postgres
+          .getRepository(entity)
+          .findOne({ where })) as Entity,
+        result: SaveQueryResultType.Inserted,
+      };
+    }
+
+    // Check if the any of values of the comparison keys have changed
+    const isChanged = comparisonKeys.some((key) => data[key] !== dbEntity[key]);
+    // Check if the data moved in finalised state
+    const isFinalisedChanged = data.finalised && !dbEntity.finalised;
+
+    if (isChanged) {
+      await this.postgres.getRepository(entity).update(where, data);
+      if (isFinalisedChanged) {
+        return {
+          data: (await this.postgres
+            .getRepository(entity)
+            .findOne({ where })) as Entity,
+          result: SaveQueryResultType.UpdatedAndFinalised,
+        };
+      }
+      return {
+        data: (await this.postgres
+          .getRepository(entity)
+          .findOne({ where })) as Entity,
+        result: SaveQueryResultType.Updated,
+      };
+    }
+
+    if (isFinalisedChanged) {
+      await this.postgres.getRepository(entity).update(where, data);
+      return {
+        data: (await this.postgres
+          .getRepository(entity)
+          .findOne({ where })) as Entity,
+        result: SaveQueryResultType.Finalised,
+      };
+    }
+
+    return {
+      data: undefined,
+      result: SaveQueryResultType.Nothing,
+    };
+  }
+}

--- a/packages/indexer-database/src/utils/BlockchainEventRepository.ts
+++ b/packages/indexer-database/src/utils/BlockchainEventRepository.ts
@@ -69,13 +69,12 @@ export class BlockchainEventRepository {
     const dbEntity = await this.postgres
       .getRepository(entity)
       .findOne({ where });
+    const repository = this.postgres.getRepository(entity);
 
     if (!dbEntity) {
-      await this.postgres.getRepository(entity).insert(data);
+      await repository.insert(data);
       return {
-        data: (await this.postgres
-          .getRepository(entity)
-          .findOne({ where })) as Entity,
+        data: (await repository.findOne({ where })) as Entity,
         result: SaveQueryResultType.Inserted,
       };
     }
@@ -86,29 +85,23 @@ export class BlockchainEventRepository {
     const isFinalisedChanged = data.finalised && !dbEntity.finalised;
 
     if (isChanged) {
-      await this.postgres.getRepository(entity).update(where, data);
+      await repository.update(where, data);
       if (isFinalisedChanged) {
         return {
-          data: (await this.postgres
-            .getRepository(entity)
-            .findOne({ where })) as Entity,
+          data: (await repository.findOne({ where })) as Entity,
           result: SaveQueryResultType.UpdatedAndFinalised,
         };
       }
       return {
-        data: (await this.postgres
-          .getRepository(entity)
-          .findOne({ where })) as Entity,
+        data: (await repository.findOne({ where })) as Entity,
         result: SaveQueryResultType.Updated,
       };
     }
 
     if (isFinalisedChanged) {
-      await this.postgres.getRepository(entity).update(where, data);
+      await repository.update(where, data);
       return {
-        data: (await this.postgres
-          .getRepository(entity)
-          .findOne({ where })) as Entity,
+        data: (await repository.findOne({ where })) as Entity,
         result: SaveQueryResultType.Finalised,
       };
     }

--- a/packages/indexer-database/src/utils/index.ts
+++ b/packages/indexer-database/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./BaseRepository";
+export * from "./BlockchainEventRepository";

--- a/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
+++ b/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
@@ -110,12 +110,12 @@ export class AcrossIndexerManager {
         return spokePoolIndexer;
       },
     );
+    this.spokePoolIndexers = spokePoolIndexers;
 
-    if (spokePoolIndexers.length === 0) {
+    if (this.spokePoolIndexers.length === 0) {
       this.logger.warn("No spoke pool indexers to start");
       return;
     }
-    this.spokePoolIndexers = spokePoolIndexers;
     return Promise.all(
       this.spokePoolIndexers.map((indexer) => indexer.start()),
     );

--- a/packages/indexer/src/database/SpokePoolRepository.ts
+++ b/packages/indexer/src/database/SpokePoolRepository.ts
@@ -3,13 +3,13 @@ import * as across from "@across-protocol/sdk";
 import { DataSource, entities, utils as dbUtils } from "@repo/indexer-database";
 import * as utils from "../utils";
 
-export class SpokePoolRepository extends dbUtils.BaseRepository {
+export class SpokePoolRepository extends dbUtils.BlockchainEventRepository {
   constructor(
     postgres: DataSource,
     logger: winston.Logger,
     private chunkSize = 2000,
   ) {
-    super(postgres, logger, true);
+    super(postgres, logger);
   }
 
   public updateDepositEventWithIntegratorId(id: number, integratorId: string) {

--- a/packages/indexer/src/database/SpokePoolRepository.ts
+++ b/packages/indexer/src/database/SpokePoolRepository.ts
@@ -7,7 +7,7 @@ export class SpokePoolRepository extends dbUtils.BlockchainEventRepository {
   constructor(
     postgres: DataSource,
     logger: winston.Logger,
-    private chunkSize = 2000,
+    private chunkSize = 100,
   ) {
     super(postgres, logger);
   }
@@ -48,7 +48,7 @@ export class SpokePoolRepository extends dbUtils.BlockchainEventRepository {
         finalised: event.blockNumber <= lastFinalisedBlock,
       };
     });
-    const chunkedEvents = across.utils.chunk(formattedEvents, 100);
+    const chunkedEvents = across.utils.chunk(formattedEvents, this.chunkSize);
     const savedEvents = await Promise.all(
       chunkedEvents.map((eventsChunk) =>
         this.saveAndHandleFinalisationBatch<entities.V3FundsDeposited>(


### PR DESCRIPTION
- new [BlockchainEventRepository](https://github.com/across-protocol/indexer/pull/103/files#diff-c7565999fde564c1bde14abd561f7bd626a30813513746d1d9bd03163d7366a0) which is intended to be extended by any repository class dealing with events entities.
- [BlockchainEventRepository.saveAndHandleFinalisation()]() is a function which takes event data and performs a save operation depending on the passed `uniqueKeys` and `comparisonKeys`. The result of this save operation can be  (1) **Nothing** if the data is identical to what's stored in the database , (2) **Inserted**, if the unique keys are not present in the DB, (3) **Finalised**, if the finalised field was the only one that changed, (4) **Updated**, if any of the data fields were changed, (5) **UpdatedAndFinalised**, if both the finalised field and other fields were changed
- [filterSaveQueryResults](https://github.com/across-protocol/indexer/pull/103/files#diff-c7565999fde564c1bde14abd561f7bd626a30813513746d1d9bd03163d7366a0R6-R14) takes a list of `SaveQueryResult[]` and filters the data based on a `SaveQueryResultType`, so for example, we can know which events were inserted in the DB for the first time
- `SpokePoolProcessor` functions were updated to perform operations only when necessary (mostly on `Inserted` and `Updated` entities) 
- [TODOs marks](https://github.com/across-protocol/indexer/pull/103/files#diff-b5925a4c81447e8689bf4dbb44dd7419585f80a247caf816407d515b21d26befR40-R72) where webhooks should be triggered

![Across Indexer (15)](https://github.com/user-attachments/assets/1331d8f4-0188-4a05-9f09-a90076e273d8)

