### PR TITLE
improve(spokePoolProcessor): improved logic for setting refunded status

### DIFF
--- a/packages/indexer/src/services/BundleIncludedEventsService.ts
+++ b/packages/indexer/src/services/BundleIncludedEventsService.ts
@@ -1,13 +1,9 @@
-import { CHAIN_IDs } from "@across-protocol/constants";
 import * as across from "@across-protocol/sdk";
 import Redis from "ioredis";
 import winston from "winston";
 import { DataSource, entities } from "@repo/indexer-database";
 import { BaseIndexer } from "../generics";
-import {
-  BlockRangeInsertType,
-  BundleRepository,
-} from "../database/BundleRepository";
+import { BundleRepository } from "../database/BundleRepository";
 import * as utils from "../utils";
 import { getBlockTime } from "../web3/constants";
 import {


### PR DESCRIPTION
Previously, we were querying the expired deposits and then querying its possible refunds. Now, we are getting from the database only the deposits that might be refunded based on the bundle events that are stored in the db.

This PR also fixes the bug we were having before (Cannot read properties of undefined, reading `relayerRefundRoot`). The issue was fixed by including the inner join with the bundle table when querying bundle events.