### PR TITLE
chore: replace info-level logs with debug

### DIFF
--- a/packages/indexer-api/src/database/database.provider.ts
+++ b/packages/indexer-api/src/database/database.provider.ts
@@ -7,7 +7,7 @@ export async function connectToDatabase(
 ) {
   try {
     const database = await createDataSource(databaseConfig).initialize();
-    logger.info({
+    logger.debug({
       at: "IndexerAPI#connectToDatabase",
       message: "Postgres connection established",
     });
@@ -16,6 +16,7 @@ export async function connectToDatabase(
     logger.error({
       at: "IndexerAPI#connectToDatabase",
       message: "Unable to connect to database",
+      notificationPath: "across-indexer-error",
       error,
     });
     throw error;

--- a/packages/indexer-api/src/main.ts
+++ b/packages/indexer-api/src/main.ts
@@ -18,8 +18,8 @@ async function initializeRedis(
 
   return new Promise<Redis>((resolve, reject) => {
     redis.on("ready", () => {
-      logger.info({
-        at: "Indexer-API",
+      logger.debug({
+        at: "IndexerAPI",
         message: "Redis connection established",
         config,
       });
@@ -28,8 +28,9 @@ async function initializeRedis(
 
     redis.on("error", (err) => {
       logger.error({
-        at: "Indexer-API",
+        at: "IndexerAPI",
         message: "Redis connection failed",
+        notificationPath: "across-indexer-error",
         error: err,
       });
       reject(err);
@@ -42,7 +43,7 @@ export async function connectToDatabase(
 ) {
   try {
     const database = await createDataSource(databaseConfig).initialize();
-    logger.info({
+    logger.debug({
       at: "IndexerAPI#connectToDatabase",
       message: "Postgres connection established",
     });
@@ -51,6 +52,7 @@ export async function connectToDatabase(
     logger.error({
       at: "IndexerAPI#connectToDatabase",
       message: "Unable to connect to database",
+      notificationPath: "across-indexer-error",
       error,
     });
     throw error;
@@ -102,8 +104,8 @@ export async function Main(
   const app = ExpressApp(allRouters);
 
   logger.info({
+    at: "IndexerAPI#Main",
     message: `Starting indexer api on port ${port}`,
-    at: "main.ts",
   });
   void (await new Promise((res) => {
     app.listen(port, () => res(app));

--- a/packages/indexer-api/src/main.ts
+++ b/packages/indexer-api/src/main.ts
@@ -19,7 +19,7 @@ async function initializeRedis(
   return new Promise<Redis>((resolve, reject) => {
     redis.on("ready", () => {
       logger.debug({
-        at: "IndexerAPI",
+        at: "IndexerAPI#initializeRedis",
         message: "Redis connection established",
         config,
       });
@@ -28,7 +28,7 @@ async function initializeRedis(
 
     redis.on("error", (err) => {
       logger.error({
-        at: "IndexerAPI",
+        at: "IndexerAPI#initializeRedis",
         message: "Redis connection failed",
         notificationPath: "across-indexer-error",
         error: err,

--- a/packages/indexer-database/src/utils/BaseRepository.ts
+++ b/packages/indexer-database/src/utils/BaseRepository.ts
@@ -21,7 +21,7 @@ export class BaseRepository {
         .values(data)
         .returning("*")
         .execute();
-      this.logger.info({
+      this.logger.debug({
         at: "BaseRepository#insert",
         message: `Saved ${data.length} ${repository.metadata.name} events`,
       });
@@ -30,6 +30,7 @@ export class BaseRepository {
       this.logger.error({
         at: "BaseRepository#insert",
         message: `There was an error while saving ${repository.metadata.name} events`,
+        notificationPath: "across-indexer-error",
         error,
       });
       if (throwError || this.throwError) {

--- a/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
+++ b/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
@@ -55,7 +55,10 @@ export class AcrossIndexerManager {
 
   private startHubPoolIndexer() {
     if (!this.config.enableHubPoolIndexer) {
-      this.logger.warn("Hub pool indexer is disabled");
+      this.logger.warn({
+        at: "Indexer#AcrossIndexerManager#startHubPoolIndexer",
+        message: "Hub pool indexer is disabled",
+      });
       return;
     }
     const hubPoolIndexerDataHandler = new HubPoolIndexerDataHandler(
@@ -113,7 +116,10 @@ export class AcrossIndexerManager {
     this.spokePoolIndexers = spokePoolIndexers;
 
     if (this.spokePoolIndexers.length === 0) {
-      this.logger.warn("No spoke pool indexers to start");
+      this.logger.warn({
+        at: "Indexer#AcrossIndexerManager#startSpokePoolIndexers",
+        message: "No spoke pool indexers to start",
+      });
       return;
     }
     return Promise.all(

--- a/packages/indexer/src/data-indexing/service/HubPoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/HubPoolIndexerDataHandler.ts
@@ -50,8 +50,8 @@ export class HubPoolIndexerDataHandler implements IndexerDataHandler {
     blockRange: BlockRange,
     lastFinalisedBlock: number,
   ) {
-    this.logger.info({
-      at: "HubPoolIndexerDataHandler::processBlockRange",
+    this.logger.debug({
+      at: "Indexer#HubPoolIndexerDataHandler#processBlockRange",
       message: `Start processing block range ${this.getDataIdentifier()}`,
       blockRange,
       lastFinalisedBlock,
@@ -64,8 +64,8 @@ export class HubPoolIndexerDataHandler implements IndexerDataHandler {
     let events: FetchEventsResult;
 
     if (this.cachedFetchEventsResult) {
-      this.logger.info({
-        at: "HubPoolIndexerDataHandler::processBlockRange",
+      this.logger.debug({
+        at: "Indexer#HubPoolIndexerDataHandler#processBlockRange",
         message: `Using cached events for ${this.getDataIdentifier()}`,
       });
       events = this.cachedFetchEventsResult;
@@ -74,8 +74,8 @@ export class HubPoolIndexerDataHandler implements IndexerDataHandler {
       this.cachedFetchEventsResult = events;
     }
 
-    this.logger.info({
-      at: "HubPoolIndexerDataHandler::processBlockRange",
+    this.logger.debug({
+      at: "Indexer#HubPoolIndexerDataHandler#processBlockRange",
       message: `Fetched events ${this.getDataIdentifier()}`,
       events: {
         proposedRootBundleEvents: events.proposedRootBundleEvents.length,
@@ -88,8 +88,8 @@ export class HubPoolIndexerDataHandler implements IndexerDataHandler {
       identifier: this.getDataIdentifier(),
     });
     await this.storeEvents(events, lastFinalisedBlock);
-    this.logger.info({
-      at: "HubPoolIndexerDataHandler::processBlockRange",
+    this.logger.debug({
+      at: "Indexer#HubPoolIndexerDataHandler#processBlockRange",
       message: `Finished processing block range ${this.getDataIdentifier()}`,
       blockRange,
       lastFinalisedBlock,

--- a/packages/indexer/src/data-indexing/service/Indexer.ts
+++ b/packages/indexer/src/data-indexing/service/Indexer.ts
@@ -51,8 +51,8 @@ export class Indexer {
         }
 
         if (!blockRangeResult?.blockRange) {
-          this.logger.info({
-            at: "Indexer::start",
+          this.logger.debug({
+            at: "Indexer#start",
             message: `No new blocks to process ${this.dataHandler.getDataIdentifier()}`,
             blockRangeResult,
             dataIdentifier: this.dataHandler.getDataIdentifier(),
@@ -70,8 +70,10 @@ export class Indexer {
         blockRangeProcessedSuccessfully = true;
       } catch (error) {
         this.logger.error({
-          at: "Indexer::start",
+          at: "Indexer#start",
           message: "Error processing block range",
+          notificationPath: "across-indexer-error",
+          blockRangeResult,
           dataIdentifier: this.dataHandler.getDataIdentifier(),
           error,
         });
@@ -80,8 +82,8 @@ export class Indexer {
         if (!blockRangeResult?.isBackfilling) {
           await across.utils.delay(this.config.loopWaitTimeSeconds);
         } else {
-          this.logger.info({
-            at: "Indexer::start",
+          this.logger.debug({
+            at: "Indexer#start",
             message: `Skip delay ${this.dataHandler.getDataIdentifier()}. Backfill in progress...`,
             dataIdentifier: this.dataHandler.getDataIdentifier(),
           });
@@ -96,7 +98,7 @@ export class Indexer {
    */
   public stopGracefully() {
     this.logger.info({
-      at: "Indexer::stopGracefully",
+      at: "Indexer#stopGracefully",
       message: `Requesting indexer ${this.dataHandler.getDataIdentifier()} to be stopped`,
     });
     this.stopRequested = true;

--- a/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
@@ -73,8 +73,8 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
     blockRange: BlockRange,
     lastFinalisedBlock: number,
   ) {
-    this.logger.info({
-      at: "SpokePoolIndexerDataHandler::processBlockRange",
+    this.logger.debug({
+      at: "Indexer#SpokePoolIndexerDataHandler#processBlockRange",
       message: `Processing block range ${this.getDataIdentifier()}`,
       blockRange,
       lastFinalisedBlock,
@@ -91,8 +91,8 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
     ).reduce((acc, speedUps) => {
       return acc + Object.values(speedUps).length;
     }, 0);
-    this.logger.info({
-      at: "SpokePoolIndexerDataHandler::processBlockRange",
+    this.logger.debug({
+      at: "Indexer#SpokePoolIndexerDataHandler#processBlockRange",
       message: `Found events for ${this.getDataIdentifier()}`,
       events: {
         v3FundsDepositedEvents: events.v3FundsDepositedEvents.length,

--- a/packages/indexer/src/database/database.provider.ts
+++ b/packages/indexer/src/database/database.provider.ts
@@ -7,7 +7,7 @@ export async function connectToDatabase(
 ) {
   try {
     const database = await createDataSource(databaseConfig).initialize();
-    logger.info({
+    logger.debug({
       at: "Indexer#connectToDatabase",
       message: "Postgres connection established",
     });
@@ -16,6 +16,7 @@ export async function connectToDatabase(
     logger.error({
       at: "Indexer#connectToDatabase",
       message: "Unable to connect to database",
+      notificationPath: "across-indexer-error",
       error,
     });
     throw error;

--- a/packages/indexer/src/generics/BaseIndexer.ts
+++ b/packages/indexer/src/generics/BaseIndexer.ts
@@ -12,7 +12,7 @@ export abstract class BaseIndexer {
     private readonly name: string,
   ) {
     this.logger.debug({
-      at: "BaseIndexer#constructor",
+      at: "Indexer#BaseIndexer#constructor",
       message: `Instantiated indexer ${name}`,
     });
   }
@@ -25,8 +25,8 @@ export abstract class BaseIndexer {
    * @param delay The delay in seconds between each iteration of the indexer
    */
   public async start(delay: number): Promise<void> {
-    this.logger.info({
-      at: "BaseIndexer#start",
+    this.logger.debug({
+      at: "Indexer#BaseIndexer#start",
       message: `Starting indexer ${this.name}`,
     });
 
@@ -35,8 +35,9 @@ export abstract class BaseIndexer {
       await this.initialize();
     } catch (e) {
       this.logger.error({
-        at: "BaseIndexer#start",
+        at: "Indexer#BaseIndexer#start",
         message: `Failed to initialize ${this.name}`,
+        notificationPath: "across-indexer-error",
         error: (e as unknown as Error).message,
       });
       return;
@@ -48,8 +49,8 @@ export abstract class BaseIndexer {
       await across.utils.delay(delay);
     } while (!this.stopRequested);
 
-    this.logger.info({
-      at: "BaseIndexer#start",
+    this.logger.debug({
+      at: "Indexer#BaseIndexer#start",
       message: `Ended halted ${this.name}`,
     });
   }
@@ -60,7 +61,7 @@ export abstract class BaseIndexer {
    */
   public stop(): void {
     this.logger.info({
-      at: "BaseIndexer#stop",
+      at: "Indexer#BaseIndexer#stop",
       message: `Requesting indexer ${this.name} to be stopped`,
     });
     this.stopRequested = true;

--- a/packages/indexer/src/main.ts
+++ b/packages/indexer/src/main.ts
@@ -30,7 +30,7 @@ async function initializeRedis(
 
   return new Promise<Redis>((resolve, reject) => {
     redis.on("ready", () => {
-      logger.info({
+      logger.debug({
         at: "Indexer#initializeRedis",
         message: "Redis connection established",
         config,
@@ -42,6 +42,7 @@ async function initializeRedis(
       logger.error({
         at: "Indexer#initializeRedis",
         message: "Redis connection failed",
+        notificationPath: "across-indexer-error",
         error: err,
       });
       reject(err);
@@ -50,7 +51,7 @@ async function initializeRedis(
 }
 
 export async function Main(config: parseEnv.Config, logger: winston.Logger) {
-  const { redisConfig, postgresConfig, hubChainId } = config;
+  const { redisConfig, postgresConfig } = config;
   const redis = await initializeRedis(redisConfig, logger);
   const redisCache = new RedisCache(redis);
   const postgres = await connectToDatabase(postgresConfig, logger);
@@ -137,9 +138,9 @@ export async function Main(config: parseEnv.Config, logger: winston.Logger) {
     }
   });
 
-  logger.info({
-    message: "Running indexers",
+  logger.debug({
     at: "Indexer#Main",
+    message: "Running indexers",
   });
   // start all indexers in parallel, will wait for them to complete, but they all loop independently
   const [bundleServicesManagerResults, acrossIndexerManagerResult] =

--- a/packages/indexer/src/services/BundleBuilderService.ts
+++ b/packages/indexer/src/services/BundleBuilderService.ts
@@ -63,8 +63,8 @@ export class BundleBuilderService extends BaseIndexer {
     // of heap memory errors from needing to aggregate too much historical data
     // from all the chains.
     if (!(await this.isCloseEnoughToHead(lastExecutedBundle.proposal))) {
-      this.logger.info({
-        at: "BundleBuilder#Processor#indexerLogic",
+      this.logger.debug({
+        at: "Indexer#BundleBuilderService#indexerLogic",
         message: "Last executed bundle is too far from head, skipping",
         lastExecutedBundleBlock: lastExecutedBundle.proposal.blockNumber,
       });
@@ -82,8 +82,8 @@ export class BundleBuilderService extends BaseIndexer {
       this.handleHubBalanceAggregation(lastExecutedBundle),
     ]);
 
-    this.logger.info({
-      at: "BundleBuilderService#indexerLogic",
+    this.logger.debug({
+      at: "Indexer#BundleBuilderService#indexerLogic",
       message: "Bundle builder loop completed",
       currentLoopResult: currentLoopResult.status,
       proposedLoopResult: proposedLoopResult.status,
@@ -171,9 +171,10 @@ export class BundleBuilderService extends BaseIndexer {
         // Confirm that our current bundle data is not empty
         if (!currentBundleData || currentBundleData.length === 0) {
           this.logger.error({
-            at: "BundleBuilder#Processor#handleHubBalanceAggregation",
+            at: "Indexer#BundleBuilderService#handleHubBalanceAggregation",
             message:
               "No current bundle data found. Ensure that the current bundle loop has been run.",
+            notificationPath: "across-indexer-error",
             l1Token,
           });
           return;
@@ -296,7 +297,7 @@ export class BundleBuilderService extends BaseIndexer {
     // If no proposed bundle is found, skip the rest of the logic
     if (!utils.isDefined(lastProposedBundle)) {
       this.logger.debug({
-        at: "BundleBuilder#Processor#handleProposedBundleLoop",
+        at: "Indexer#BundleBuilderService#handleProposedBundleLoop",
         message: "No proposed bundles found, skipping.",
       });
       // Clear the cache so that we don't have any stale data
@@ -373,8 +374,9 @@ export class BundleBuilderService extends BaseIndexer {
     // an ample lookback range
     if (!historicalProposal) {
       this.logger.error({
-        at: "BundleBuilder#Processor#callRange",
+        at: "Indexer#BundleBuilderService#callRange",
         message: "No historical proposal found",
+        notificationPath: "across-indexer-error",
       });
       throw new Error("No historical proposal found");
     }

--- a/packages/indexer/src/services/BundleIncludedEventsService.ts
+++ b/packages/indexer/src/services/BundleIncludedEventsService.ts
@@ -47,7 +47,7 @@ export class BundleIncludedEventsService extends BaseIndexer {
         at: "Indexer#BundleIncludedEventsService#indexerLogic",
         message: "Error in BundleIncludedEventsService",
         notificationPath: "across-indexer-error",
-        error,
+        error: JSON.stringify(error),
       });
     }
   }

--- a/packages/indexer/src/services/BundleIncludedEventsService.ts
+++ b/packages/indexer/src/services/BundleIncludedEventsService.ts
@@ -32,20 +32,21 @@ export class BundleIncludedEventsService extends BaseIndexer {
 
   protected async indexerLogic(): Promise<void> {
     try {
-      this.config.logger.info({
-        at: "BundleIncludedEventsService#indexerLogic",
+      this.config.logger.debug({
+        at: "Indexer#BundleIncludedEventsService#indexerLogic",
         message: "Starting BundleIncludedEventsService",
       });
       await this.assignSpokePoolEventsToExecutedBundles();
 
-      this.config.logger.info({
-        at: "BundleIncludedEventsService#indexerLogic",
+      this.config.logger.debug({
+        at: "Indexer#BundleIncludedEventsService#indexerLogic",
         message: "Finished BundleIncludedEventsService",
       });
     } catch (error) {
       this.logger.error({
-        at: "BundleIncludedEventsService#indexerLogic",
+        at: "Indexer#BundleIncludedEventsService#indexerLogic",
         message: "Error in BundleIncludedEventsService",
+        notificationPath: "across-indexer-error",
         error,
       });
     }
@@ -63,8 +64,8 @@ export class BundleIncludedEventsService extends BaseIndexer {
       await bundleRepository.getExecutedBundlesWithoutEventsAssociated({
         fromBlock: utils.ACROSS_V3_MAINNET_DEPLOYMENT_BLOCK,
       });
-    logger.info({
-      at: "ExecutedBundleEventsService#assignSpokePoolEventsToExecutedBundles",
+    logger.debug({
+      at: "Indexer#BundleIncludedEventsService#assignSpokePoolEventsToExecutedBundles",
       message: `Found ${executedBundles.length} executed bundles without events associated`,
     });
     if (executedBundles.length === 0) {
@@ -72,7 +73,7 @@ export class BundleIncludedEventsService extends BaseIndexer {
     }
 
     logger.debug({
-      at: "BundleIncludedEventsService#assignSpokePoolEventsToExecutedBundles",
+      at: "Indexer#BundleIncludedEventsService#assignSpokePoolEventsToExecutedBundles",
       message: "Updating HubPool and ConfigStore clients",
     });
     const startTime = Date.now();
@@ -81,7 +82,7 @@ export class BundleIncludedEventsService extends BaseIndexer {
     const endTime = Date.now();
     const duration = endTime - startTime;
     logger.debug({
-      at: "BundleIncludedEventsService#assignSpokePoolEventsToExecutedBundles",
+      at: "Indexer#BundleIncludedEventsService#assignSpokePoolEventsToExecutedBundles",
       message: `Updated HubPool and ConfigStore clients in ${duration / 1000} seconds`,
     });
 
@@ -102,7 +103,7 @@ export class BundleIncludedEventsService extends BaseIndexer {
     // Skip the bundle if we don't have enough historical data
     if (!historicalBundle) {
       logger.warn({
-        at: "BundleIncludedEventsService#getEventsIncludedInBundle",
+        at: "Indexer#BundleIncludedEventsService#getEventsIncludedInBundle",
         message: `No historical bundle found. Skipping bundle reconstruction of bundle ${bundle.id}`,
       });
       return;
@@ -116,7 +117,7 @@ export class BundleIncludedEventsService extends BaseIndexer {
       spokePoolClientFactory,
     );
     logger.debug({
-      at: "BundleIncludedEventsService#getEventsIncludedInBundle",
+      at: "Indexer#BundleIncludedEventsService#getEventsIncludedInBundle",
       message: `Updating spoke clients for lookback range for bundle ${bundle.id}`,
       lookbackRange,
     });
@@ -127,7 +128,7 @@ export class BundleIncludedEventsService extends BaseIndexer {
     const endTime = Date.now();
     const duration = endTime - startTime;
     logger.debug({
-      at: "BundleIncludedEventsService#getEventsIncludedInBundle",
+      at: "Indexer#BundleIncludedEventsService#getEventsIncludedInBundle",
       message: `Updated spoke clients in ${duration / 1000} seconds for bundle ${bundle.id}`,
     });
     const clients = {
@@ -159,7 +160,7 @@ export class BundleIncludedEventsService extends BaseIndexer {
     );
     if (bundle.poolRebalanceRoot !== poolRebalanceRoot.tree.getHexRoot()) {
       logger.warn({
-        at: "BundleIncludedEventsService#getEventsIncludedInBundle",
+        at: "Indexer#BundleIncludedEventsService#getEventsIncludedInBundle",
         message: `Mismatching roots. Skipping bundle ${bundle.id}.`,
       });
       return;
@@ -169,8 +170,8 @@ export class BundleIncludedEventsService extends BaseIndexer {
         bundle.id,
       );
       await bundleRepository.updateBundleEventsAssociatedFlag(bundle.id);
-      logger.info({
-        at: "BundleIncludedEventsService#getEventsIncludedInBundle",
+      logger.debug({
+        at: "Indexer#BundleIncludedEventsService#getEventsIncludedInBundle",
         message: `Stored bundle events for bundle ${bundle.id}`,
         storedEvents,
       });

--- a/packages/indexer/src/services/BundleServicesManager.ts
+++ b/packages/indexer/src/services/BundleServicesManager.ts
@@ -45,7 +45,10 @@ export class BundleServicesManager {
 
   private startBundleIncludedEventsService() {
     if (!this.config.enableBundleIncludedEventsService) {
-      this.logger.warn("Bundle included events service is disabled");
+      this.logger.warn({
+        at: "Indexer#BundleServicesManager#startBundleIncludedEventsService",
+        message: "Bundle included events service is disabled",
+      });
       return;
     }
     this.bundleIncludedEventsService = new BundleIncludedEventsService({
@@ -62,7 +65,10 @@ export class BundleServicesManager {
 
   private startBundleEventsProcessor() {
     if (!this.config.enableBundleEventsProcessor) {
-      this.logger.warn("Bundle events processor is disabled");
+      this.logger.warn({
+        at: "Indexer#BundleServicesManager#startBundleEventsProcessor",
+        message: "Bundle events processor is disabled",
+      });
       return;
     }
     this.bundleEventsProcessor = new BundleEventsProcessor({
@@ -76,7 +82,10 @@ export class BundleServicesManager {
 
   private startBundleBuilderService() {
     if (!this.config.enableBundleBuilder) {
-      this.logger.warn("Bundle builder service is disabled");
+      this.logger.warn({
+        at: "Indexer#BundleServicesManager#startBundleBuilderService",
+        message: "Bundle builder service is disabled",
+      });
       return;
     }
 

--- a/packages/indexer/src/services/bundles.ts
+++ b/packages/indexer/src/services/bundles.ts
@@ -37,8 +37,8 @@ export class BundleEventsProcessor extends BaseIndexer {
 
   protected async indexerLogic(): Promise<void> {
     try {
-      this.config.logger.info({
-        at: "BundleEventsProcessor#indexerLogic",
+      this.config.logger.debug({
+        at: "Indexer#BundleEventsProcessor#indexerLogic",
         message: "Starting bundle events processor",
       });
       const { logger, bundleRepository } = this.config;
@@ -48,8 +48,8 @@ export class BundleEventsProcessor extends BaseIndexer {
       await assignBundleRangesToProposal(bundleRepository, logger);
       await assignExecutionsToBundle(bundleRepository, logger);
       await assignBundleExecutedStatus(bundleRepository, logger);
-      this.config.logger.info({
-        at: "BundleEventsProcessor#indexerLogic",
+      this.config.logger.debug({
+        at: "Indexer#BundleEventsProcessor#indexerLogic",
         message: "Finished bundle events processor",
       });
     } catch (error) {
@@ -60,7 +60,7 @@ export class BundleEventsProcessor extends BaseIndexer {
   protected async initialize(): Promise<void> {
     if (!this.config.postgres) {
       this.logger.error({
-        at: "Bundles#Processor",
+        at: "Indexer#BundleEventsProcessor#initialize",
         message: "Postgres connection not provided",
       });
       throw new ConfigurationMalformedError();
@@ -83,8 +83,8 @@ function logResultOfAssignment(
   persistedRecordsCount: number,
 ): void {
   if (unassociatedRecordsCount > 0) {
-    logger.info({
-      at: `Bundles#assignToBundle`,
+    logger.debug({
+      at: `Indexer#BundleEventsProcessor#assignToBundle`,
       message: "Found and associated events with bundles",
       unassociatedRecordsCount,
       persistedRecordsCount,
@@ -198,7 +198,7 @@ async function assignExecutionsToBundle(
           );
         if (!proposedBundle) {
           logger.error({
-            at: "Bundles#assignExecutionsToBundle",
+            at: "Indexer#BundleEventsProcessor#assignExecutionsToBundle",
             message: "Unable to find a proposed bundle for the given execution",
             executionId: id,
           });
@@ -239,8 +239,8 @@ async function assignBundleRangesToProposal(
     dbRepository.retrieveUnassociatedCanceledEvents(),
   ]);
   if (unassociatedDisputes.length > 0 || unassociatedCancellations.length > 0) {
-    logger.info({
-      at: "Bundles#assignBundleRangesToProposal",
+    logger.debug({
+      at: "Indexer#BundleEventsProcessor#assignBundleRangesToProposal",
       message:
         "Unassociated disputes or cancellations found. Unable to assign ranges.",
       unassociatedDisputes: unassociatedDisputes.length,
@@ -342,8 +342,8 @@ async function assignBundleExecutedStatus(
 ): Promise<void> {
   const updateCount = await dbRepository.updateBundleExecutedStatus();
   if (updateCount) {
-    logger.info({
-      at: "Bundles#assignBundleExecutedStatus",
+    logger.debug({
+      at: "Indexer#BundleEventsProcessor#assignBundleExecutedStatus",
       message: "Updated bundles with executed status",
       bundlesUpdatedWithExecutedStatus: updateCount,
     });

--- a/packages/indexer/src/services/spokePoolProcessor.ts
+++ b/packages/indexer/src/services/spokePoolProcessor.ts
@@ -126,8 +126,8 @@ export class SpokePoolProcessor {
         relayHashInfoRepository.upsert(chunk, ["relayHash"]),
       ),
     );
-    this.logger.info({
-      at: "SpokePoolProcessor#assignSpokeEventsToRelayHashInfo",
+    this.logger.debug({
+      at: "Indexer#SpokePoolProcessor#assignSpokeEventsToRelayHashInfo",
       message: `${eventType} events associated with RelayHashInfo`,
       updatedRelayHashInfoRows: upsertResult.reduce(
         (acc, res) => acc + res.generatedMaps.length,
@@ -144,8 +144,8 @@ export class SpokePoolProcessor {
     const relayHashInfoRepository = this.postgres.getRepository(
       entities.RelayHashInfo,
     );
-    this.logger.info({
-      at: "SpokePoolProcessor#updateExpiredRelays",
+    this.logger.debug({
+      at: "Indexer#SpokePoolProcessor#updateExpiredRelays",
       message: `Updating status for expired relays`,
     });
     const expiredDeposits = await relayHashInfoRepository
@@ -164,8 +164,8 @@ export class SpokePoolProcessor {
       .execute();
 
     if ((expiredDeposits.affected ?? 0) > 0) {
-      this.logger.info({
-        at: "SpokePoolProcessor#updateExpiredRelays",
+      this.logger.debug({
+        at: "Indexer#SpokePoolProcessor#updateExpiredRelays",
         message: `Updated status for ${expiredDeposits.affected} expired relays`,
       });
     }
@@ -182,8 +182,8 @@ export class SpokePoolProcessor {
   private async updateRefundedDepositsStatus(): Promise<
     entities.RelayHashInfo[]
   > {
-    this.logger.info({
-      at: "SpokePoolProcessor#updateRefundedDepositsStatus",
+    this.logger.debug({
+      at: "Indexer#SpokePoolProcessor#updateRefundedDepositsStatus",
       message: `Updating status for refunded deposits`,
     });
     const bundleEventsRepository = this.postgres.getRepository(
@@ -258,8 +258,8 @@ export class SpokePoolProcessor {
       updatedRow && updatedRows.push(updatedRow);
     }
     if (updatedRows.length > 0) {
-      this.logger.info({
-        at: "SpokePoolProcessor#updateRefundedDepositsStatus",
+      this.logger.debug({
+        at: "Indexer#SpokePoolProcessor#updateRefundedDepositsStatus",
         message: `Updated ${updatedRows.length} refunded deposits`,
       });
     }

--- a/packages/indexer/src/utils/bundleBuilderUtils.ts
+++ b/packages/indexer/src/utils/bundleBuilderUtils.ts
@@ -34,8 +34,9 @@ export async function resolveMostRecentProposedAndExecutedBundles(
   // If no executed bundle is found, the system is in an inconsistent state
   if (!utils.isDefined(lastExecutedBundle)) {
     logger.error({
+      at: "Indexer#resolveMostRecentProposedAndExecutedBundles",
       message: "No executed bundles found",
-      at: "resolveMostRecentProposedAndExecutedBundles",
+      notificationPath: "across-indexer-error",
     });
     throw new Error("No executed bundles found");
   }
@@ -47,9 +48,10 @@ export async function resolveMostRecentProposedAndExecutedBundles(
       lastExecutedBundle.proposal.blockNumber
   ) {
     logger.error({
+      at: "Indexer#resolveMostRecentProposedAndExecutedBundles",
       message:
         "Inconsistent state: found proposed bundle is older than last executed bundle",
-      at: "resolveMostRecentProposedAndExecutedBundles",
+      notificationPath: "across-indexer-error",
       proposedBundleHash: lastProposedBundle!.proposal.transactionHash,
       lastExecutedBundleHash: lastExecutedBundle.proposal.transactionHash,
     });

--- a/packages/indexer/src/utils/contractFactoryUtils.ts
+++ b/packages/indexer/src/utils/contractFactoryUtils.ts
@@ -20,9 +20,9 @@ abstract class ContractClientFactory<
     protected readonly requiredFactories: RequiredFactories,
   ) {
     logger.debug({
+      at: "Indexer#ContractClientFactory#constructor",
       message: "Initializing contract client factory",
       factory: this.constructor.name,
-      at: "ContractClientFactory#constructor",
     });
   }
 

--- a/packages/indexer/src/utils/contractUtils.ts
+++ b/packages/indexer/src/utils/contractUtils.ts
@@ -55,8 +55,8 @@ export function getSpokeClient(
     maxBlockLookBack,
   };
   logger.debug({
+    at: "Indexer#contractUtils#getSpokePoolClient",
     message: "Initializing spoke pool",
-    at: "getSpokeClient",
     chainId,
     address,
     deployedBlockNumber,
@@ -154,8 +154,8 @@ export function getHubPoolClient(
     toBlock,
     maxBlockLookBack,
   };
-  logger.info({
-    at: "getHubPoolClient",
+  logger.debug({
+    at: "Indexer#contractUtils#getHubPoolClient",
     message: "Initializing hubpool",
     chainId,
     ...eventSearchConfig,

--- a/packages/webhooks/src/notifier.ts
+++ b/packages/webhooks/src/notifier.ts
@@ -1,6 +1,5 @@
 import { post } from "./utils";
 import { NotificationPayload } from "./types";
-import { AsyncStore } from "./store";
 import { Logger } from "winston";
 
 export type Dependencies = {
@@ -15,7 +14,12 @@ export class BaseNotifier {
 
   public notify = (payload: NotificationPayload): void => {
     this.deps.notify(payload).catch((error) => {
-      this.logger.error(`Error calling webhook`, error);
+      this.logger.error({
+        at: "BaseNotifier#notify",
+        message: `Error calling webhook`,
+        notificationPath: "across-indexer-error",
+        error,
+      });
     });
   };
 }


### PR DESCRIPTION
In order to use UMA's logger to send logs to slack, we should reduce the number of info logs in the indexer.

This PR:
- Replaces almost all info logs with debug logs
- For error-level logs, it sets the notificationPath key to "across-indexer-error" so that those are sent to a error specific channel.
- Adds the "Indexer" or "IndexerAPI" prefix to the "at" value of all logs so that we can easily filter in GCP and exclude SDK logs.

Zion PR to config slack channels: https://github.com/UMAprotocol/zion/pull/429