### PR TITLE
feat(webhooks): allow client registration through env

### DIFF
--- a/packages/indexer-api/src/main.ts
+++ b/packages/indexer-api/src/main.ts
@@ -87,10 +87,12 @@ export async function Main(
   const postgres = await connectToDatabase(postgresConfig, logger);
   const redisConfig = Indexer.parseRedisConfig(env);
   const redis = await initializeRedis(redisConfig, logger);
-  const webhooks = Webhooks.WebhookFactory(
+  const webhooks = await Webhooks.WebhookFactory(
     {
       enabledWebhooks: [Webhooks.WebhookTypes.DepositStatus],
       enabledWebhookRequestWorkers: false,
+      // indexer will register clients
+      clients: [],
     },
     { postgres, logger, redis },
   );

--- a/packages/indexer-database/src/entities/WebhookClient.ts
+++ b/packages/indexer-database/src/entities/WebhookClient.ts
@@ -2,6 +2,7 @@ import { Entity, Column, PrimaryGeneratedColumn, Unique } from "typeorm";
 
 @Entity()
 @Unique("UK_webhook_client_api_key", ["apiKey"])
+@Unique("UK_webhook_client_name", ["name"])
 export class WebhookClient {
   @PrimaryGeneratedColumn()
   id: number;

--- a/packages/indexer-database/src/migrations/1732730161339-Webhook.ts
+++ b/packages/indexer-database/src/migrations/1732730161339-Webhook.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Webhook1732730161339 implements MigrationInterface {
+  name = "Webhook1732730161339";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "webhook_client" ADD CONSTRAINT "UQ_a08bea1c3eba7711301141ae001" UNIQUE ("name")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "webhook_client" DROP CONSTRAINT "UQ_a08bea1c3eba7711301141ae001"`,
+    );
+  }
+}

--- a/packages/indexer/src/main.ts
+++ b/packages/indexer/src/main.ts
@@ -56,13 +56,11 @@ export async function Main(config: parseEnv.Config, logger: winston.Logger) {
   const redisCache = new RedisCache(redis);
   const postgres = await connectToDatabase(postgresConfig, logger);
   // Call write to kick off webhook calls
-  const { write } = WebhookFactory(
-    {
-      enabledWebhooks: [WebhookTypes.DepositStatus],
-      enabledWebhookRequestWorkers: true,
-    },
-    { postgres, logger, redis },
-  );
+  const { write } = await WebhookFactory(config.webhookConfig, {
+    postgres,
+    logger,
+    redis,
+  });
   // Retry providers factory
   const retryProvidersFactory = new RetryProvidersFactory(
     redisCache,

--- a/packages/indexer/src/parseEnv.ts
+++ b/packages/indexer/src/parseEnv.ts
@@ -2,6 +2,11 @@ import * as s from "superstruct";
 import { DatabaseConfig } from "@repo/indexer-database";
 import { getNoTtlBlockDistance } from "./web3/constants";
 import { assert } from "@repo/error-handling";
+import {
+  Config as WebhooksConfig,
+  WebhookTypes,
+  parseWebhookClientsFromString,
+} from "@repo/webhooks";
 
 export type Config = {
   redisConfig: RedisConfig;
@@ -12,6 +17,7 @@ export type Config = {
   enableBundleEventsProcessor: boolean;
   enableBundleIncludedEventsService: boolean;
   enableBundleBuilder: boolean;
+  webhookConfig: WebhooksConfig;
 };
 export type RedisConfig = {
   host: string;
@@ -182,6 +188,11 @@ export function envToConfig(env: Env): Config {
       `SPOKEPOOL_CHAINS_ENABLED=${chainId} but did not find any corresponding RPC_PROVIDER_URLS_${chainId}`,
     );
   });
+  const webhookConfig = {
+    enabledWebhooks: [WebhookTypes.DepositStatus],
+    enabledWebhookRequestWorkers: true,
+    clients: parseWebhookClientsFromString(env.WEBHOOK_CLIENTS ?? "[]"),
+  };
   return {
     redisConfig,
     postgresConfig,
@@ -191,5 +202,6 @@ export function envToConfig(env: Env): Config {
     enableBundleEventsProcessor,
     enableBundleIncludedEventsService,
     enableBundleBuilder,
+    webhookConfig,
   };
 }

--- a/packages/webhooks/src/database/webhookClientRepository.ts
+++ b/packages/webhooks/src/database/webhookClientRepository.ts
@@ -1,4 +1,5 @@
 import { entities, DataSource } from "@repo/indexer-database";
+import { exists } from "../utils";
 import assert from "assert";
 
 // This class is intended to store integration clients allowed to use the webhook service.
@@ -9,14 +10,30 @@ export class WebhookClientRepository {
     this.repository = this.dataSource.getRepository(entities.WebhookClient);
   }
 
-  public async registerClient(client: entities.WebhookClient): Promise<void> {
-    const existingClient = await this.repository.findOne({
-      where: { id: client.id },
-    });
-    if (existingClient) {
-      throw new Error(`Client with id ${client.id} already exists.`);
+  public async registerClient(
+    client: Omit<entities.WebhookClient, "id">,
+  ): Promise<entities.WebhookClient> {
+    assert(
+      !(await this.hasClientByName(client.name)),
+      "Client with that name already exists",
+    );
+    const result = await this.repository.insert(client);
+    return result.raw[0];
+  }
+  public async upsertClient(
+    client: Omit<entities.WebhookClient, "id">,
+  ): Promise<entities.WebhookClient> {
+    if (await this.hasClientByName(client.name)) {
+      return this.updateClientByName(client);
+    } else {
+      return this.registerClient(client);
     }
-    await this.repository.insert(client);
+  }
+  public async updateClientByName(
+    client: Omit<entities.WebhookClient, "id">,
+  ): Promise<entities.WebhookClient> {
+    const result = await this.repository.update({ name: client.name }, client);
+    return result.raw[0];
   }
 
   public async unregisterClient(clientId: number): Promise<void> {
@@ -40,12 +57,20 @@ export class WebhookClientRepository {
   public async listClients(): Promise<entities.WebhookClient[]> {
     return this.repository.find();
   }
-
+  public async hasClientByName(name: string): Promise<boolean> {
+    const result = await this.repository.findOne({ where: { name } });
+    return exists(result);
+  }
+  public async getClientByName(name: string): Promise<entities.WebhookClient> {
+    const result = await this.repository.findOne({ where: { name } });
+    assert(result, `Client by name: ${name} does not exist`);
+    return result;
+  }
   public async getClientByApiKey(
     apiKey: string,
   ): Promise<entities.WebhookClient> {
     const result = await this.repository.findOne({ where: { apiKey } });
-    assert(result, "Invalid api key");
+    assert(result, `Client by apiKey: ${apiKey} does not exist`);
     return result;
   }
 

--- a/packages/webhooks/src/types.ts
+++ b/packages/webhooks/src/types.ts
@@ -37,3 +37,13 @@ export const UnregisterParams = ss.object({
   id: ss.string(),
 });
 export type UnregisterParams = ss.Infer<typeof UnregisterParams>;
+
+export const PartialWebhookClient = ss.type({
+  name: ss.string(),
+  apiKey: ss.string(),
+  domains: ss.array(ss.string()),
+});
+export type PartialWebhookClient = ss.Infer<typeof PartialWebhookClient>;
+
+export const PartialWebhookClients = ss.array(PartialWebhookClient);
+export type PartialWebhookClients = ss.Infer<typeof PartialWebhookClients>;

--- a/packages/webhooks/src/utils.ts
+++ b/packages/webhooks/src/utils.ts
@@ -1,4 +1,5 @@
-import { NotificationPayload } from "./types";
+import { NotificationPayload, PartialWebhookClients } from "./types";
+import * as ss from "superstruct";
 export async function post(params: NotificationPayload): Promise<void> {
   const { url, data, apiKey } = params;
   const response = await fetch(url, {
@@ -41,4 +42,11 @@ export function exists<T>(val: T | null | undefined): val is T {
 }
 export function customId(...args: (string | number)[]): string {
   return args.join("!");
+}
+
+export function parseWebhookClientsFromString(
+  envStr: string,
+): PartialWebhookClients {
+  const clients = JSON.parse(envStr);
+  return ss.create(clients, PartialWebhookClients);
 }


### PR DESCRIPTION
# motivation
we need an easy way to add and update arbitrary webhook clients

# changes
this adds env config var to regsiter new clients as well as removes domain checks to make it easier for testing