### PR TITLE
fix: check for overflow in configs

### DIFF
--- a/packages/indexer/src/data-indexing/service/Indexer.ts
+++ b/packages/indexer/src/data-indexing/service/Indexer.ts
@@ -119,7 +119,10 @@ export class Indexer {
     const lastFinalisedBlockOnChain =
       latestBlockNumber - this.config.finalisedBlockBufferDistance;
 
-    if (lastBlockFinalisedStored === lastFinalisedBlockOnChain) {
+    if (
+      lastBlockFinalisedStored !== null &&
+      lastBlockFinalisedStored >= lastFinalisedBlockOnChain
+    ) {
       return {
         latestBlockNumber,
         blockRange: undefined,


### PR DESCRIPTION
There's a possibility that if the `lastBlockFinalizedStored` is greater than the `lastFinalizedBlockOnChain` then we will have the from block be larger than the to block