### PR TITLE
fix: aleph zero block time

### DIFF
--- a/packages/indexer/src/services/bundles.ts
+++ b/packages/indexer/src/services/bundles.ts
@@ -82,7 +82,7 @@ function logResultOfAssignment(
   unassociatedRecordsCount: number,
   persistedRecordsCount: number,
 ): void {
-  if (unassociatedRecordsCount > 0) {
+  if (persistedRecordsCount > 0) {
     logger.debug({
       at: `Indexer#BundleEventsProcessor#assignToBundle`,
       message: "Found and associated events with bundles",
@@ -294,7 +294,11 @@ async function assignBundleRangesToProposal(
     }),
   );
   const insertResults = await dbRepository.associateBlockRangeWithBundle(
-    rangeSegments.filter((segment) => segment !== undefined).flat(),
+    rangeSegments
+      .filter(
+        (segment): segment is BlockRangeInsertType[] => segment !== undefined,
+      )
+      .flat(),
   );
   logResultOfAssignment(
     logger,

--- a/packages/indexer/src/web3/constants.ts
+++ b/packages/indexer/src/web3/constants.ts
@@ -110,7 +110,7 @@ export function getMaxBlockLookBack(chainId: number) {
 
 // Average block time in seconds by chain
 export const BLOCK_TIME_SECONDS: { [chainId: number]: number } = {
-  [CHAIN_IDs.ALEPH_ZERO]: 0.25,
+  [CHAIN_IDs.ALEPH_ZERO]: 2,
   [CHAIN_IDs.ARBITRUM]: 0.25,
   [CHAIN_IDs.BASE]: 2,
   [CHAIN_IDs.BLAST]: 2,


### PR DESCRIPTION
We were making requests for blocks that were not minted yet because Aleph Zero's block time is higher that the one we had set.

+2 minor improvements.