### PR TITLE
feat: Add depositTxHash index to RelayHashInfo table

### DIFF
--- a/packages/indexer-database/src/entities/RelayHashInfo.ts
+++ b/packages/indexer-database/src/entities/RelayHashInfo.ts
@@ -3,6 +3,7 @@ import {
   CreateDateColumn,
   Entity,
   JoinColumn,
+  Index,
   OneToOne,
   PrimaryGeneratedColumn,
   Unique,
@@ -24,6 +25,8 @@ export enum RelayStatus {
 
 @Entity()
 @Unique("UK_relayHashInfo_relayHash", ["relayHash"])
+@Index("IX_rhi_originChainId_depositId", ["originChainId", "depositId"])
+@Index("IX_rhi_depositTxHash", ["depositTxHash"])
 export class RelayHashInfo {
   @PrimaryGeneratedColumn()
   id: number;

--- a/packages/indexer-database/src/migrations/1733247042958-RelayHashInfo.ts
+++ b/packages/indexer-database/src/migrations/1733247042958-RelayHashInfo.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RelayHashInfo1733247042958 implements MigrationInterface {
+  name = "RelayHashInfo1733247042958";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IX_rhi_depositTxHash" ON "relay_hash_info" ("depositTxHash") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IX_rhi_originChainId_depositId" ON "relay_hash_info" ("originChainId", "depositId") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IX_rhi_originChainId_depositId"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IX_rhi_depositTxHash"`);
+  }
+}


### PR DESCRIPTION
This PR creates two indices for RelayHashInfo table:
- originChainId, depositId
- depositTxHash