### PR TITLE
improve(indexer): add block timestamp to depositevent data

### DIFF
--- a/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
+++ b/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
@@ -89,4 +89,7 @@ export class V3FundsDeposited {
 
   @CreateDateColumn()
   createdAt: Date;
+
+  @Column({ nullable: true })
+  blockTimestamp?: number;
 }

--- a/packages/indexer-database/src/migrations/1733407862578-V3FundsDeposited.ts
+++ b/packages/indexer-database/src/migrations/1733407862578-V3FundsDeposited.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class V3FundsDeposited1733407862578 implements MigrationInterface {
+  name = "V3FundsDeposited1733407862578";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."v3_funds_deposited" ADD "blockTimestamp" integer`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."v3_funds_deposited" DROP COLUMN "blockTimestamp"`,
+    );
+  }
+}

--- a/packages/indexer/src/database/SpokePoolRepository.ts
+++ b/packages/indexer/src/database/SpokePoolRepository.ts
@@ -61,7 +61,23 @@ export class SpokePoolRepository extends dbUtils.BlockchainEventRepository {
         ),
       ),
     );
-    return savedEvents.flat();
+    const result = savedEvents.flat();
+
+    // Log the time difference for each deposit event for profiling in datadog
+    const now = Date.now();
+    formattedEvents.forEach((event) => {
+      if (event.blockTimestamp === undefined) return;
+      const timeDifference = now - event.blockTimestamp * 1000;
+      this.logger.info({
+        message: "V3FundsDepositedEvent profile",
+        depositId: event.depositId,
+        chainId: event.originChainId,
+        timeDifference,
+        now,
+        blockTimestamp: event.blockTimestamp,
+      });
+    });
+    return result;
   }
 
   public async formatAndSaveFilledV3RelayEvents(

--- a/packages/indexer/src/database/SpokePoolRepository.ts
+++ b/packages/indexer/src/database/SpokePoolRepository.ts
@@ -38,6 +38,7 @@ export class SpokePoolRepository extends dbUtils.BlockchainEventRepository {
   public async formatAndSaveV3FundsDepositedEvents(
     v3FundsDepositedEvents: utils.V3FundsDepositedWithIntegradorId[],
     lastFinalisedBlock: number,
+    blockTimes: Record<number, number>,
   ) {
     const formattedEvents = v3FundsDepositedEvents.map((event) => {
       return {
@@ -46,6 +47,7 @@ export class SpokePoolRepository extends dbUtils.BlockchainEventRepository {
         ...this.formatRelayData(event),
         quoteTimestamp: new Date(event.quoteTimestamp * 1000),
         finalised: event.blockNumber <= lastFinalisedBlock,
+        blockTimestamp: blockTimes[event.blockNumber],
       };
     });
     const chunkedEvents = across.utils.chunk(formattedEvents, this.chunkSize);


### PR DESCRIPTION
# motivation
We want to store block timestamps with deposit data in order to calculate some metrics

# changes
This adds a column "blockTimestamp" to v3FundsDeposited, and queries per block range all the block timestamps and adds it to the data when storing in database

# profiling
We will use this new value and the existing "createdAt" value, which is our insertion time, for instance:
`const depositWriteTime = toSeconds(deposit.createdAt) - deposit.blockTimestamp`