### PR TITLE
fix: chain ids mistakenly included in proposal entity

### DIFF
--- a/packages/indexer/src/data-indexing/service/HubPoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/HubPoolIndexerDataHandler.ts
@@ -147,7 +147,11 @@ export class HubPoolIndexerDataHandler implements IndexerDataHandler {
       // we need to make sure we filter out all unecessary events for the block range requested
       proposedRootBundleEvents: proposedRootBundleEvents.map((p) => ({
         ...p,
-        chainIds: configStoreClient.getChainIdIndicesForBlock(p.blockNumber),
+        // Ensure both bundleEvaluationBlockNumbers and chainIds are the same length as
+        // a chain might be included in the config store list but not in a bundle yet.
+        chainIds: configStoreClient
+          .getChainIdIndicesForBlock(p.blockNumber)
+          .slice(0, p.bundleEvaluationBlockNumbers.length),
       })),
       rootBundleCanceledEvents,
       rootBundleDisputedEvents,


### PR DESCRIPTION
For a bundle which block ranges are:

[21181520, 127967611, 64250084, 977154, 274166888, 48874544, 22372326, 12024812, 15683208, 8402604, 11362092, 11072547, 9674454, 22420080, 6099180]

We are seting chainIds to:

[1, 10, 137, 288, 42161, 324, 8453, 59144, 34443, 1135, 81457, 534352, 690, 7777777, 480, 41455]

But 41455 shouldn't be part of it yet.

This is causing we trying to update a spoke pool with this config

```
searchConfig: {
  fromBlock: "NaN"
  maxBlockLookBack: 10000
  toBlock: "NaN"
}
```

Proposal chain ids are mistakenly configured every time a new chain is added.
