### PR TITLE
fix: profile events storage relatively to insertion timestamp

### DIFF
--- a/packages/indexer/src/database/SpokePoolRepository.ts
+++ b/packages/indexer/src/database/SpokePoolRepository.ts
@@ -68,22 +68,6 @@ export class SpokePoolRepository extends dbUtils.BlockchainEventRepository {
       ),
     );
     const result = savedEvents.flat();
-
-    // Log the time difference for each deposit event for profiling in datadog
-    const now = new Date();
-    formattedEvents.forEach((event) => {
-      if (event.blockTimestamp === undefined) return;
-      const timeDifference = now.getTime() - event.blockTimestamp.getTime();
-      this.logger.debug({
-        at: "SpokePoolRepository#formatAndSaveV3FundsDepositedEvents",
-        message: "V3FundsDepositedEvent profile",
-        depositId: event.depositId,
-        chainId: event.originChainId,
-        timeDifference,
-        now,
-        blockTimestamp: event.blockTimestamp,
-      });
-    });
     return result;
   }
 


### PR DESCRIPTION
For more accurate profiling, we need to compute the time difference relatively to the time the event was inserted in the DB, not the current `now()` server timestamp at logging time.

In addition, now we profile fill events storing too