### PR TITLE
fix: revert redstone max block lookback

### DIFF
--- a/packages/indexer/src/web3/constants.ts
+++ b/packages/indexer/src/web3/constants.ts
@@ -83,7 +83,7 @@ const MAX_BLOCK_LOOK_BACK = {
   [CHAIN_IDs.BOBA]: 4990,
   [CHAIN_IDs.INK]: 10000,
   [CHAIN_IDs.ZK_SYNC]: 10000,
-  [CHAIN_IDs.REDSTONE]: 500, // TODO: Update when Quicknode is enable as a provider
+  [CHAIN_IDs.REDSTONE]: 10000,
   [CHAIN_IDs.LISK]: 10000,
   [CHAIN_IDs.BASE]: 10000,
   [CHAIN_IDs.MODE]: 10000,


### PR DESCRIPTION
During local testing I see that the public Redstone RPC supports 10k block ranges again