### PR TITLE
feat: track indexer class progress in sql

### DIFF
--- a/packages/indexer-database/src/entities/IndexerProgressInfo.ts
+++ b/packages/indexer-database/src/entities/IndexerProgressInfo.ts
@@ -1,0 +1,42 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+@Entity()
+export class IndexerProgressInfo {
+  /**
+   * The identifier of the blockchain indexer.
+   * Usually this id has the format of `<CONTRACT_ADDRESS>-<CHAIN_ID>`.
+   */
+  @PrimaryColumn()
+  id: string;
+
+  /**
+   * The last finalised block number that has been processed by the indexer.
+   */
+  @Column()
+  lastFinalisedBlock: number;
+
+  /**
+   * The latest onchain block number at the time of the last
+   * indexer progress info update.
+   */
+  @Column()
+  latestBlockNumber: number;
+
+  /**
+   * Whether the indexer is still backfilling.
+   */
+  @Column()
+  isBackfilling: boolean;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/packages/indexer-database/src/entities/index.ts
+++ b/packages/indexer-database/src/entities/index.ts
@@ -22,3 +22,5 @@ export * from "./RelayHashInfo";
 
 export * from "./WebhookRequest";
 export * from "./WebhookClient";
+
+export * from "./IndexerProgressInfo";

--- a/packages/indexer-database/src/main.ts
+++ b/packages/indexer-database/src/main.ts
@@ -39,6 +39,8 @@ export const createDataSource = (config: DatabaseConfig): DataSource => {
       // Webhooks
       entities.WebhookRequest,
       entities.WebhookClient,
+      // Indexer
+      entities.IndexerProgressInfo,
     ],
     migrationsTableName: "_migrations",
     migrations: ["migrations/*.ts"],

--- a/packages/indexer-database/src/migrations/1737589453070-IndexerProgressInfo.ts
+++ b/packages/indexer-database/src/migrations/1737589453070-IndexerProgressInfo.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class IndexerProgressInfo1737589453070 implements MigrationInterface {
+  name = "IndexerProgressInfo1737589453070";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "indexer_progress_info" (
+        "id" character varying NOT NULL, 
+        "lastFinalisedBlock" integer NOT NULL, 
+        "latestBlockNumber" integer NOT NULL, 
+        "isBackfilling" boolean NOT NULL, 
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(), 
+        CONSTRAINT "PK_7c077a22af710355c7d83c00096" PRIMARY KEY ("id"))
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "indexer_progress_info"`);
+  }
+}

--- a/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
+++ b/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
@@ -81,6 +81,7 @@ export class AcrossIndexerManager {
       this.retryProvidersFactory.getProviderForChainId(this.config.hubChainId),
       this.redisCache,
       this.logger,
+      this.postgres,
     );
 
     return this.hubPoolIndexer.start();
@@ -117,6 +118,7 @@ export class AcrossIndexerManager {
           this.retryProvidersFactory.getProviderForChainId(chainId),
           this.redisCache,
           this.logger,
+          this.postgres,
         );
         return spokePoolIndexer;
       },


### PR DESCRIPTION
There is a new `IndexerProgressInfo` entity for tracking in the SQL DB the progress for each instantiated `Indexer` class.

For each `Indexer` identifier we store: 
- `lastFinalisedBlock` The last finalised block number that has been processed by the indexer
- `latestBlockNumber` The latest onchain block number at the time of the last indexer progress info update
- `isBackfilling` Whether the indexer is still backfilling

The next step will be to move the `Indexer` from reading the `lastFinalisedBlock` value from Redis to reading it from SQL