### PR TITLE
improve(performance): disable quote block lookup in spoke indexer

### DIFF
--- a/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
+++ b/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
@@ -66,9 +66,6 @@ export class V3FundsDeposited {
   @Column()
   quoteTimestamp: Date;
 
-  @Column()
-  quoteBlockNumber: number;
-
   @Column({ nullable: true })
   integratorId?: string;
 

--- a/packages/indexer-database/src/migrations/1737658101626-V3FundsDeposited.ts
+++ b/packages/indexer-database/src/migrations/1737658101626-V3FundsDeposited.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class V3FundsDeposited1737658101626 implements MigrationInterface {
+  name = "V3FundsDeposited1737658101626";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."v3_funds_deposited" DROP COLUMN "quoteBlockNumber"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."v3_funds_deposited" ADD "quoteBlockNumber" integer NOT NULL`,
+    );
+  }
+}

--- a/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
@@ -271,17 +271,6 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
     ]);
     const timeToUpdateSpokePoolClient = performance.now();
 
-    this.logger.debug({
-      at: "SpokePoolIndexerDataHandler#fetchEventsByRange",
-      message: "Time to update protocol clients",
-      timeToUpdateProtocolClients: timeToUpdateProtocolClients - initialTime,
-      timeToUpdateSpokePoolClient:
-        timeToUpdateSpokePoolClient - timeToUpdateProtocolClients,
-      totalTime: timeToUpdateSpokePoolClient - initialTime,
-      spokeChainId: this.chainId,
-      blockRange: blockRange,
-    });
-
     const v3FundsDepositedEvents = spokePoolClient.getDeposits({
       fromBlock: blockRange.from,
       toBlock: blockRange.to,
@@ -299,7 +288,22 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
       ...v3FundsDepositedEvents.map((deposit) => deposit.blockNumber),
       ...filledV3RelayEvents.map((fill) => fill.blockNumber),
     ];
+
+    const startTimeToGetBlockTimes = performance.now();
     const blockTimes = await this.getBlockTimes(blockNumbers);
+    const endTimeToGetBlockTimes = performance.now();
+
+    this.logger.debug({
+      at: "SpokePoolIndexerDataHandler#fetchEventsByRange",
+      message: "Time to update protocol clients",
+      timeToUpdateProtocolClients: timeToUpdateProtocolClients - initialTime,
+      timeToUpdateSpokePoolClient:
+        timeToUpdateSpokePoolClient - timeToUpdateProtocolClients,
+      timeToGetBlockTimes: endTimeToGetBlockTimes - startTimeToGetBlockTimes,
+      totalTime: endTimeToGetBlockTimes - initialTime,
+      spokeChainId: this.chainId,
+      blockRange: blockRange,
+    });
 
     return {
       v3FundsDepositedEvents,

--- a/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
@@ -239,6 +239,7 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
       blockRange.to,
       {
         hubPoolClient: this.hubPoolClient,
+        disableQuoteBlockLookup: true,
       },
     );
 

--- a/packages/indexer/src/database/SpokePoolRepository.ts
+++ b/packages/indexer/src/database/SpokePoolRepository.ts
@@ -46,6 +46,7 @@ export class SpokePoolRepository extends dbUtils.BlockchainEventRepository {
       delete event.updatedRecipient;
       delete event.updatedOutputAmount;
       delete event.updatedMessage;
+      delete (event as { quoteBlockNumber?: number }).quoteBlockNumber;
       const blockTimestamp = new Date(blockTimes[event.blockNumber]! * 1000);
       return {
         ...event,

--- a/packages/indexer/src/redis/redisCache.ts
+++ b/packages/indexer/src/redis/redisCache.ts
@@ -8,7 +8,7 @@ export class RedisCache implements across.interfaces.CachingMechanismInterface {
     if (result === null) return result;
     return JSON.parse(result);
   }
-  set<ObjectType, OverrideType>(
+  set<ObjectType, _OverrideType>(
     key: string,
     value: ObjectType,
     ttl?: number,

--- a/packages/indexer/src/utils/clients/SpokePoolClient.ts
+++ b/packages/indexer/src/utils/clients/SpokePoolClient.ts
@@ -1,0 +1,42 @@
+import * as across from "@across-protocol/sdk";
+import { Contract } from "ethers";
+import winston from "winston";
+
+export class SpokePoolClient extends across.clients.SpokePoolClient {
+  constructor(
+    logger: winston.Logger,
+    spokePool: Contract,
+    hubPoolClient: across.clients.HubPoolClient | null,
+    chainId: number,
+    deploymentBlock: number,
+    eventSearchConfig?: across.utils.MakeOptional<
+      across.utils.EventSearchConfig,
+      "toBlock"
+    >,
+    private disableQuoteBlockLookup = false,
+  ) {
+    super(
+      logger,
+      spokePool,
+      hubPoolClient,
+      chainId,
+      deploymentBlock,
+      eventSearchConfig,
+    );
+  }
+
+  protected getBlockNumbers(
+    timestamps: number[],
+  ): Promise<{ [quoteTimestamp: number]: number }> {
+    return this.hubPoolClient && !this.disableQuoteBlockLookup
+      ? this.hubPoolClient.getBlockNumbers(timestamps)
+      : Promise.resolve(
+          Object.fromEntries(
+            timestamps.map((timestamp) => [
+              timestamp,
+              across.utils.MAX_BIG_INT.toNumber(),
+            ]),
+          ),
+        );
+  }
+}

--- a/packages/indexer/src/utils/clients/index.ts
+++ b/packages/indexer/src/utils/clients/index.ts
@@ -1,0 +1,1 @@
+export { SpokePoolClient } from "./SpokePoolClient";

--- a/packages/indexer/src/utils/contractFactoryUtils.ts
+++ b/packages/indexer/src/utils/contractFactoryUtils.ts
@@ -132,6 +132,7 @@ export class SpokePoolClientFactory extends ContractClientFactory<
     fromBlock?: number,
     toBlock?: number,
     overrides?: {
+      disableQuoteBlockLookup?: boolean;
       hubPoolClient: clients.HubPoolClient;
     },
   ): clients.SpokePoolClient {
@@ -151,6 +152,7 @@ export class SpokePoolClientFactory extends ContractClientFactory<
       hubPoolClient,
       fromBlock,
       toBlock,
+      disableQuoteBlockLookup: overrides?.disableQuoteBlockLookup,
     });
   }
 }

--- a/packages/indexer/src/utils/contractUtils.ts
+++ b/packages/indexer/src/utils/contractUtils.ts
@@ -20,6 +20,7 @@ export type GetSpokeClientParams = {
   toBlock?: number;
   chainId: number;
   hubPoolClient: across.clients.HubPoolClient;
+  disableQuoteBlockLookup?: boolean;
 };
 
 function getAddress(contractName: string, chainId: number): string {
@@ -49,6 +50,8 @@ export function getSpokeClient(
   const toBlock = params.toBlock;
   const fromBlock = params.fromBlock ?? deployedBlockNumber;
 
+  const disableQuoteBlockLookup = params.disableQuoteBlockLookup ?? false;
+
   const eventSearchConfig = {
     fromBlock,
     toBlock,
@@ -75,6 +78,7 @@ export function getSpokeClient(
     chainId,
     deployedBlockNumber,
     eventSearchConfig,
+    disableQuoteBlockLookup,
   );
 }
 

--- a/packages/indexer/src/utils/contractUtils.ts
+++ b/packages/indexer/src/utils/contractUtils.ts
@@ -8,6 +8,7 @@ import {
 import winston from "winston";
 import * as across from "@across-protocol/sdk";
 import { providers, Contract } from "ethers";
+import { SpokePoolClient } from "./clients";
 
 export const CONFIG_STORE_VERSION = 4;
 export const ACROSS_V3_MAINNET_DEPLOYMENT_BLOCK = 19277710;
@@ -71,7 +72,7 @@ export function getSpokeClient(
     SpokePoolFactory.abi,
     provider,
   );
-  return new across.clients.SpokePoolClient(
+  return new SpokePoolClient(
     logger,
     spokePoolContract,
     hubPoolClient,


### PR DESCRIPTION
This change removes the resolution of `quoteBlockNumber` from the spoke event indexer. It currently is not used in the context of deposit/fill lookups. This change does **not** remove the resolution of the `quoteBlockNumber` in the context of bundle creation/resolution.

Reason:
The `quoteBlockNumber` resolution in the SpokePoolClient requires a binary search to be completed from the deployment block. Since our calls are on increasing ranges and since we don't use the resolved value, we simply burn time resolving the values. 

Below is an example of the time it takes to resolve `v3FundsDeposited` which has this lookup. Note that it is 99% of the 120 seconds taken to update the spoke pool.

```
2025-01-23 16:22:15 [[34mdebug[39m]: {
  "at": "SpokePoolClient",
  "chainId": 1,
  "message": "SpokePool client for chain 1 updated!",
  "nextFirstBlockToSearch": 21079185,
  "elapsedMs": 122322.120625,
  "tokensBridgedTime": 0.10362499999973807,
  "v3FundsDepositedTime": 122198.531792,
  "requestedSpeedUpV3DepositTime": 0.22808299999451265,
  "requestedV3SlowFillTime": 1.4373750000086147,
  "filledV3RelayTime": 120.83100000000559,
  "enabledDepositRouteTime": 0.0027919999847654253,
  "relayedRootBundleTime": 0.07720800000242889,
  "executedRelayerRefundRootTime": 0.7112079999933485,
  "bot-identifier": "NO_BOT_ID",
  "run-identifier": "d2b7f368-ba0d-46aa-93a6-600b040dfdf3"
}
```