### PR TITLE
improve(spoke-indexer): optimize external association process

### DIFF
--- a/packages/indexer-database/src/entities/RelayHashInfo.ts
+++ b/packages/indexer-database/src/entities/RelayHashInfo.ts
@@ -27,6 +27,12 @@ export enum RelayStatus {
 @Unique("UK_relayHashInfo_relayHash", ["relayHash"])
 @Index("IX_rhi_originChainId_depositId", ["originChainId", "depositId"])
 @Index("IX_rhi_depositTxHash", ["depositTxHash"])
+@Index("IX_rhi_origin_deadline_status", [
+  "originChainId",
+  "fillDeadline",
+  "status",
+])
+@Index("IX_rhi_relayHash", ["relayHash"])
 export class RelayHashInfo {
   @PrimaryGeneratedColumn()
   id: number;

--- a/packages/indexer-database/src/entities/RelayHashInfo.ts
+++ b/packages/indexer-database/src/entities/RelayHashInfo.ts
@@ -32,7 +32,6 @@ export enum RelayStatus {
   "fillDeadline",
   "status",
 ])
-@Index("IX_rhi_relayHash", ["relayHash"])
 export class RelayHashInfo {
   @PrimaryGeneratedColumn()
   id: number;

--- a/packages/indexer-database/src/migrations/1737752107825-RelayHashInfo.ts
+++ b/packages/indexer-database/src/migrations/1737752107825-RelayHashInfo.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RelayHashInfo1737752107825 implements MigrationInterface {
+  name = "RelayHashInfo1737752107825";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IX_rhi_relayHash" ON "relay_hash_info" ("relayHash") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IX_rhi_origin_deadline_status" ON "relay_hash_info" ("originChainId", "fillDeadline", "status") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IX_rhi_origin_deadline_status"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IX_rhi_relayHash"`);
+  }
+}

--- a/packages/indexer-database/src/migrations/1737752107825-RelayHashInfo.ts
+++ b/packages/indexer-database/src/migrations/1737752107825-RelayHashInfo.ts
@@ -5,9 +5,6 @@ export class RelayHashInfo1737752107825 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE INDEX "IX_rhi_relayHash" ON "relay_hash_info" ("relayHash") `,
-    );
-    await queryRunner.query(
       `CREATE INDEX "IX_rhi_origin_deadline_status" ON "relay_hash_info" ("originChainId", "fillDeadline", "status") `,
     );
   }
@@ -16,6 +13,5 @@ export class RelayHashInfo1737752107825 implements MigrationInterface {
     await queryRunner.query(
       `DROP INDEX "public"."IX_rhi_origin_deadline_status"`,
     );
-    await queryRunner.query(`DROP INDEX "public"."IX_rhi_relayHash"`);
   }
 }


### PR DESCRIPTION
### Changes
Add missing indices. Example below but over the similar ranges without cache overlap we are seeing 252ms -> 19ms. It should be noted that these ranges contain considerably less records than in the sandbox deployment so the timings are smaller in general.

### Before index:
```
2025-01-24 20:46:12 [[34mdebug[39m]: {
  "at": "Indexer#SpokePoolProcessor#process",
  "message": "System Time Log for SpokePoolProcessor#process",
  "spokeChainId": 1,
  "timeToAssignSpokeEvents": 0.17175000000861473,
  "timeToAssignSpokeEventsToRelayHashInfo": 0.04575000001932494,
  "timeToUpdateExpiredRelays": 247.56841700000223,
  "timeToUpdateRefundedDeposits": 4.181042000011075,
  "totalTime": 252.0016670000041,
  "bot-identifier": "NO_BOT_ID",
  "run-identifier": "67a618b4-0e73-4b3b-bcfd-47c045630c5a"
}
```

### After Index:
```
2025-01-24 20:57:57 [[34mdebug[39m]: {
  "at": "Indexer#SpokePoolProcessor#process",
  "message": "System Time Log for SpokePoolProcessor#process",
  "spokeChainId": 1,
  "timeToAssignSpokeEvents": 0.18608300000050804,
  "timeToAssignSpokeEventsToRelayHashInfo": 0.09633300000132294,
  "timeToUpdateExpiredRelays": 14.774791999996523,
  "timeToUpdateRefundedDeposits": 4.123875000004773,
  "totalTime": 19.222750000000815,
  "bot-identifier": "NO_BOT_ID",
  "run-identifier": "728caac9-0f22-450e-bd66-f6cea155e9f3"
}
```