### PR TITLE
improve(timing): reduce timing of lookback window

### DIFF
--- a/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
@@ -240,6 +240,7 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
       {
         hubPoolClient: this.hubPoolClient,
         disableQuoteBlockLookup: true,
+        maxBlockLookback: 200,
       },
     );
 

--- a/packages/indexer/src/utils/contractFactoryUtils.ts
+++ b/packages/indexer/src/utils/contractFactoryUtils.ts
@@ -134,6 +134,7 @@ export class SpokePoolClientFactory extends ContractClientFactory<
     overrides?: {
       disableQuoteBlockLookup?: boolean;
       hubPoolClient: clients.HubPoolClient;
+      maxBlockLookback?: number;
     },
   ): clients.SpokePoolClient {
     const hubPoolClient =
@@ -144,10 +145,13 @@ export class SpokePoolClientFactory extends ContractClientFactory<
         toBlock,
       );
 
+    const maxBlockLookBack =
+      overrides?.maxBlockLookback ?? getMaxBlockLookBack(chainId);
+
     return getSpokeClient({
       provider: this.retryProviderFactory.getProviderForChainId(chainId),
       logger: this.logger,
-      maxBlockLookBack: getMaxBlockLookBack(chainId),
+      maxBlockLookBack,
       chainId,
       hubPoolClient,
       fromBlock,


### PR DESCRIPTION
The issue lies in `paginatedEventQuery` and our `maxBlockLookback`. Specifically, the utility function getPaginatedBlockRanges is causing the problem. Within this function, we floor the starting block to the nearest multiple of the maximum lookback range, ensuring that we query as much as possible within defined block ranges (snippet below). While this is efficient for long lookbacks and works well for our bots, it creates edge cases when querying smaller ranges, such as 20 blocks.

In these cases, we end up querying from `[maxLookbackFloor, toBlock]`. The issue compounds as the toBlock approaches the next boundary without crossing it, which increases the range we need to query over. Since this process is repeated for 9 parallel queries, the effect becomes more pronounced.

This behavior explains the “saw-tooth” pattern we’re observing in the data. As we build up a longer and longer lookback by starting from the floored fromBlock, the query length increases. When we finally cross into the next floored block range, the query length resets and begins building up again.

The solution is not trivial, but the easiest way forward is to actually reduce the max lookback when we're in our production run.

```
  // Floor the requestedFromBlock to the nearest smaller multiple of the maxBlockLookBack to enhance caching.
  // This means that a range like 5 - 45 with a maxBlockLookBack of 20 would look like:
  // 0-19, 20-39, 40-45.
  // This allows us to get the max number of repeated node queries. The maximum number of "nonstandard" queries per
  // call of this function is 1.
  const flooredStartBlock = Math.floor(fromBlock / maxBlockLookBack) * maxBlockLookBack;
```