### PR TITLE
improve(lookback): dynamically set max lookback

### DIFF
--- a/packages/indexer/src/data-indexing/service/Indexer.ts
+++ b/packages/indexer/src/data-indexing/service/Indexer.ts
@@ -169,7 +169,13 @@ export class Indexer {
       blockRange.to,
       lastFinalisedBlockOnChain,
     );
-    const isBackfilling = latestBlockNumber - blockRange.to > 100_000;
+
+    // If we specifically set the max block range then do not consider this
+    // run to be a backfilling run
+    const isBackfilling =
+      !this.config.maxBlockRangeSize &&
+      latestBlockNumber - blockRange.to > 100_000;
+
     return {
       latestBlockNumber,
       blockRange,

--- a/packages/indexer/src/data-indexing/service/Indexer.ts
+++ b/packages/indexer/src/data-indexing/service/Indexer.ts
@@ -71,6 +71,7 @@ export class Indexer {
           await this.dataHandler.processBlockRange(
             blockRangeResult.blockRange,
             blockRangeResult.lastFinalisedBlock,
+            blockRangeResult.isBackfilling,
           );
           // TODO: remove Redis storage in favor of Postgres
           await this.redisCache.set(

--- a/packages/indexer/src/data-indexing/service/IndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/IndexerDataHandler.ts
@@ -21,5 +21,6 @@ export interface IndexerDataHandler {
   processBlockRange: (
     blockRange: BlockRange,
     lastFinalisedBlock: number,
+    isBackfilling?: boolean,
   ) => Promise<void>;
 }

--- a/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
@@ -244,7 +244,10 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
     // sure
     const maxBlockLookback = isBackfilling
       ? getMaxBlockLookBack(this.chainId)
-      : (blockRange.to - blockRange.from) * 2;
+      : Math.min(
+          getMaxBlockLookBack(this.chainId),
+          (blockRange.to - blockRange.from) * 2,
+        );
 
     const spokePoolClient = this.spokePoolFactory.get(
       this.chainId,

--- a/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
@@ -317,6 +317,8 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
       totalTime: endTimeToGetBlockTimes - initialTime,
       spokeChainId: this.chainId,
       blockRange: blockRange,
+      isBackfilling,
+      dynamicMaxBlockLookback: maxBlockLookback,
     });
 
     return {

--- a/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
@@ -20,6 +20,7 @@ import { SpokePoolRepository } from "../../database/SpokePoolRepository";
 import { SpokePoolProcessor } from "../../services/spokePoolProcessor";
 import { IndexerQueues, IndexerQueuesService } from "../../messaging/service";
 import { IntegratorIdMessage } from "../../messaging/IntegratorIdWorker";
+import { getMaxBlockLookBack } from "../../web3/constants";
 
 export type FetchEventsResult = {
   v3FundsDepositedEvents: utils.V3FundsDepositedWithIntegradorId[];
@@ -73,12 +74,14 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
   public async processBlockRange(
     blockRange: BlockRange,
     lastFinalisedBlock: number,
+    isBackfilling: boolean = false,
   ) {
     this.logger.debug({
       at: "Indexer#SpokePoolIndexerDataHandler#processBlockRange",
       message: `Processing block range ${this.getDataIdentifier()}`,
       blockRange,
       lastFinalisedBlock,
+      isBackfilling,
     });
 
     if (!this.isInitialized) {
@@ -89,7 +92,7 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
     //FIXME: Remove performance timing
     const startPerfTime = performance.now();
 
-    const events = await this.fetchEventsByRange(blockRange);
+    const events = await this.fetchEventsByRange(blockRange, isBackfilling);
     const requestedSpeedUpV3EventsCount = Object.values(
       events.requestedSpeedUpV3Events,
     ).reduce((acc, speedUps) => {
@@ -231,8 +234,18 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
 
   private async fetchEventsByRange(
     blockRange: BlockRange,
+    isBackfilling: boolean,
   ): Promise<FetchEventsResult> {
     const { configStoreClient, hubPoolClient } = this;
+
+    // If we are in a backfilling state then we should grab the largest
+    // lookback available to us. Otherwise, for this specific indexer we
+    // only need exactly what we're looking for, plus some padding to be
+    // sure
+    const maxBlockLookback = isBackfilling
+      ? getMaxBlockLookBack(this.chainId)
+      : (blockRange.to - blockRange.from) * 2;
+
     const spokePoolClient = this.spokePoolFactory.get(
       this.chainId,
       blockRange.from,
@@ -240,7 +253,7 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
       {
         hubPoolClient: this.hubPoolClient,
         disableQuoteBlockLookup: true,
-        maxBlockLookback: 200,
+        maxBlockLookback,
       },
     );
 


### PR DESCRIPTION
Revert to the maximum block lookback for a specific chain if the indexer is in backfilling mode. Otherwise, tighten the boundary so that we spend the minimal time required in the spoke client