### PR TITLE
chore: allow new migrated events

### DIFF
--- a/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
@@ -280,11 +280,10 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
       "RelayedRootBundle",
       "ExecutedRelayerRefundRoot",
       "TokensBridged",
-      // TODO: Uncomment these once we complete the upcoming migration
-      // "FundsDeposited",
-      // "RequestedSpeedUpDeposit",
-      // "RequestedSlowFill",
-      // "FilledRelay",
+      "FundsDeposited",
+      "RequestedSpeedUpDeposit",
+      "FilledRelay",
+      "RequestedSlowFill",
     ]);
     const timeToUpdateSpokePoolClient = performance.now();
 


### PR DESCRIPTION
Waiting for the following PRs to be merged:
* https://github.com/across-protocol/sdk/pull/829
* https://github.com/across-protocol/indexer/tree/mguevara/acx-3663-indexer-update-unique-constraints

Adds accounting for new post-migration events to be referenced by the spoke pool client