### PR TITLE
feat: handle unfinalised deposit events

### DIFF
--- a/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
+++ b/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
@@ -1,7 +1,9 @@
 import {
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
+  Index,
   PrimaryGeneratedColumn,
   Unique,
 } from "typeorm";
@@ -12,6 +14,7 @@ import {
   "blockNumber",
   "logIndex",
 ])
+@Index("IX_v3FundsDeposited_deletedAt", ["deletedAt"])
 export class V3FundsDeposited {
   @PrimaryGeneratedColumn()
   id: number;
@@ -90,4 +93,7 @@ export class V3FundsDeposited {
 
   @Column({ nullable: true })
   blockTimestamp?: Date;
+
+  @DeleteDateColumn({ nullable: true })
+  deletedAt?: Date;
 }

--- a/packages/indexer-database/src/migrations/1738721858386-DepositsDeletedAt.ts
+++ b/packages/indexer-database/src/migrations/1738721858386-DepositsDeletedAt.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DepositsDeletedAt1738721858386 implements MigrationInterface {
+  name = "DepositsDeletedAt1738721858386";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."v3_funds_deposited" ADD "deletedAt" TIMESTAMP`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IX_v3FundsDeposited_deletedAt" ON "evm"."v3_funds_deposited" ("deletedAt") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "evm"."IX_v3FundsDeposited_deletedAt"`);
+    await queryRunner.query(
+      `ALTER TABLE "evm"."v3_funds_deposited" DROP COLUMN "deletedAt"`,
+    );
+  }
+}

--- a/packages/indexer/src/database/SpokePoolRepository.ts
+++ b/packages/indexer/src/database/SpokePoolRepository.ts
@@ -253,4 +253,18 @@ export class SpokePoolRepository extends dbUtils.BlockchainEventRepository {
     );
     return savedEvents.flat();
   }
+
+  public async deleteUnfinalisedDepositEvents(
+    chainId: number,
+    lastFinalisedBlock: number,
+  ) {
+    const chainIdColumn = "originChainId";
+    const deletedDeposits = await this.deleteUnfinalisedEvents(
+      chainId,
+      chainIdColumn,
+      lastFinalisedBlock,
+      entities.V3FundsDeposited,
+    );
+    return deletedDeposits;
+  }
 }


### PR DESCRIPTION
With our recent update to how reorgs are handled for deposits (see [this change](https://github.com/across-protocol/indexer/pull/163/files#diff-cea1547b0947849dc19bac1c8b54d7c40a0f5975f4cba996111e8d560eab5db0L66-R68)), unfinalized events will now be stored in the `deposits` table. This PR introduces a new step in the `spokePoolIndexerDataHandler` to soft delete these events. The deleted events are then sent to the processor, where we'll update the related `relayHashInfo` records.

While updating `relayHashInfo`, we need to ensure that relations to other events (fills, slow fill requests, refunds) are not lost. The logic for handling this is as follows:

1. For each deleted deposit, retrieve the related `relayHashInfo` row. Since this is a one-to-one relation, we can be sure only one related row exists.
2. Check if other events are already associated with that `relayHashInfo` record:
   - If no other events exist, the row can be safely deleted.
   - If other events are already related, check for additional rows with the same `relayHash`:
     - If additional rows exist, transfer the deposit relation from one of them to the row where the other events are stored, then delete the original row.
     - If no other rows exist, set the `depositEventId` and `depositTxHash` fields to `undefined` instead of deleting the row.

 A visual example for clarity:
 
![image](https://github.com/user-attachments/assets/7002a9cf-5fca-4c39-889d-902ba0913da9)
