### PR TITLE
feat: support bundles with duplicated relay hashes

### DIFF
--- a/packages/indexer-database/src/entities/BundleEvent.ts
+++ b/packages/indexer-database/src/entities/BundleEvent.ts
@@ -16,7 +16,6 @@ export enum BundleEventType {
 }
 
 @Entity()
-@Unique("UK_bundleEvent_eventType_relayHash", ["type", "relayHash"])
 export class BundleEvent {
   @PrimaryGeneratedColumn()
   id: number;
@@ -34,5 +33,14 @@ export class BundleEvent {
   relayHash: string;
 
   @Column({ type: "decimal", nullable: true })
-  repaymentChainId: number;
+  repaymentChainId: string;
+
+  @Column({ nullable: true })
+  eventChainId: number;
+
+  @Column({ nullable: true })
+  eventBlockNumber: number;
+
+  @Column({ nullable: true })
+  eventLogIndex: number;
 }

--- a/packages/indexer-database/src/migrations/1738878727887-BundleEvents.ts
+++ b/packages/indexer-database/src/migrations/1738878727887-BundleEvents.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class BundleEvents1738878727887 implements MigrationInterface {
+  name = "BundleEvents1738878727887";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "bundle_event" DROP CONSTRAINT "UK_bundleEvent_eventType_relayHash"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "bundle_event" ADD "eventChainId" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "bundle_event" ADD "eventBlockNumber" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "bundle_event" ADD "eventLogIndex" integer`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "bundle_event" DROP COLUMN "eventLogIndex"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "bundle_event" DROP COLUMN "eventBlockNumber"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "bundle_event" DROP COLUMN "eventChainId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "bundle_event" ADD CONSTRAINT "UK_bundleEvent_eventType_relayHash" UNIQUE ("type", "relayHash")`,
+    );
+  }
+}

--- a/packages/indexer/src/database/BundleRepository.ts
+++ b/packages/indexer/src/database/BundleRepository.ts
@@ -32,6 +32,14 @@ export type PickRangeType<
   "blockNumber" | "transactionHash" | "logIndex" | "transactionIndex" | "id"
 >;
 
+type BundleEventRow = {
+  bundleId: number;
+  relayHash: string;
+  eventBlockNumber: number;
+  eventLogIndex: number;
+  type: entities.BundleEventType;
+};
+
 /**
  * An abstraction class for interacting with the database for bundle-related operations.
  */
@@ -492,6 +500,14 @@ export class BundleRepository extends utils.BaseRepository {
     bundleId: number,
   ) {
     const eventsRepo = this.postgres.getRepository(entities.BundleEvent);
+    // Delete any rows related to the bundleId we are processing to avoid storing the same bundle twice
+    const deletedRows = await eventsRepo.delete({ bundleId });
+    if (deletedRows.affected) {
+      this.logger.warn({
+        at: "BundleRepository#storeBundleEvents",
+        message: `Deleted ${deletedRows.affected} bundle events previously associated to bundle with id ${bundleId}`,
+      });
+    }
 
     // Store bundle deposits
     const deposits = this.formatBundleEvents(
@@ -501,11 +517,7 @@ export class BundleRepository extends utils.BaseRepository {
     );
     const chunkedDeposits = across.utils.chunk(deposits, this.chunkSize);
     await Promise.all(
-      chunkedDeposits.map((eventsChunk) =>
-        eventsRepo.upsert(eventsChunk, {
-          conflictPaths: { relayHash: true, type: true },
-        }),
-      ),
+      chunkedDeposits.map((eventsChunk) => eventsRepo.insert(eventsChunk)),
     );
 
     // Store bundle refunded deposits
@@ -516,11 +528,7 @@ export class BundleRepository extends utils.BaseRepository {
     );
     const chunkedRefunds = across.utils.chunk(expiredDeposits, this.chunkSize);
     await Promise.all(
-      chunkedRefunds.map((eventsChunk) =>
-        eventsRepo.upsert(eventsChunk, {
-          conflictPaths: { relayHash: true, type: true },
-        }),
-      ),
+      chunkedRefunds.map((eventsChunk) => eventsRepo.insert(eventsChunk)),
     );
 
     // Store bundle slow fills
@@ -531,11 +539,7 @@ export class BundleRepository extends utils.BaseRepository {
     );
     const chunkedSlowFills = across.utils.chunk(slowFills, this.chunkSize);
     await Promise.all(
-      chunkedSlowFills.map((eventsChunk) =>
-        eventsRepo.upsert(eventsChunk, {
-          conflictPaths: { relayHash: true, type: true },
-        }),
-      ),
+      chunkedSlowFills.map((eventsChunk) => eventsRepo.insert(eventsChunk)),
     );
 
     // Store bundle unexecutable slow fills
@@ -550,9 +554,7 @@ export class BundleRepository extends utils.BaseRepository {
     );
     await Promise.all(
       chunkedUnexecutableSlowFills.map((eventsChunk) =>
-        eventsRepo.upsert(eventsChunk, {
-          conflictPaths: { relayHash: true, type: true },
-        }),
+        eventsRepo.insert(eventsChunk),
       ),
     );
 
@@ -564,11 +566,7 @@ export class BundleRepository extends utils.BaseRepository {
     );
     const chunkedFills = across.utils.chunk(fills, this.chunkSize);
     await Promise.all(
-      chunkedFills.map((eventsChunk) =>
-        eventsRepo.upsert(eventsChunk, {
-          conflictPaths: { relayHash: true, type: true },
-        }),
-      ),
+      chunkedFills.map((eventsChunk) => eventsRepo.insert(eventsChunk)),
     );
 
     return {
@@ -588,17 +586,24 @@ export class BundleRepository extends utils.BaseRepository {
       | across.interfaces.BundleExcessSlowFills
       | across.interfaces.ExpiredDepositsToRefundV3,
     bundleId: number,
-  ): {
-    bundleId: number;
-    relayHash: string;
-    type: entities.BundleEventType;
-  }[] {
+  ): BundleEventRow[] {
     return Object.values(bundleEvents).flatMap((tokenEvents) =>
       Object.values(tokenEvents).flatMap((events) =>
         events.map((event) => {
           return {
             bundleId,
             relayHash: across.utils.getRelayHashFromEvent(event),
+            // eventChainId must match the chain the event was emmitted on
+            // For deposits and expired deposits use originChainId
+            // For slowFills and unexecutableSlowFills use destinationChainId
+            eventChainId: [
+              entities.BundleEventType.Deposit,
+              entities.BundleEventType.ExpiredDeposit,
+            ].includes(eventsType)
+              ? event.originChainId
+              : event.destinationChainId,
+            eventBlockNumber: event.blockNumber,
+            eventLogIndex: event.logIndex,
             type: eventsType,
           };
         }),
@@ -610,17 +615,16 @@ export class BundleRepository extends utils.BaseRepository {
     eventsType: entities.BundleEventType.Fill,
     bundleEvents: across.interfaces.BundleFillsV3,
     bundleId: number,
-  ): {
-    bundleId: number;
-    relayHash: string;
-    type: entities.BundleEventType.Fill;
-  }[] {
+  ): (BundleEventRow & { repaymentChainId: string })[] {
     return Object.entries(bundleEvents).flatMap(([chainId, tokenEvents]) =>
       Object.values(tokenEvents).flatMap((fillsData) =>
         fillsData.fills.map((event) => {
           return {
             bundleId,
             relayHash: across.utils.getRelayHashFromEvent(event),
+            eventChainId: event.destinationChainId,
+            eventBlockNumber: event.blockNumber,
+            eventLogIndex: event.logIndex,
             type: eventsType,
             repaymentChainId: chainId,
           };


### PR DESCRIPTION
Recent UMIP rule changes and duplicated deposits have introduced two new cases that the indexer must handle:

- A filler can be repaid multiple times if there are duplicate deposits matching it.
- A depositor may receive multiple refunds for a duplicate deposit if those deposits expire or are slow-filled.

To support these, we are adding the following fields to the BundleEvents table:
- eventChainId
- eventBlockNumber
- eventLogIndex

These fields will be populated using the data from the BundleDataClient and will be used to accurately match relayHashInfo records with their corresponding refunds.