### PR TITLE
fix: set internalHash as not nullable

### DIFF
--- a/packages/indexer-database/src/entities/RelayHashInfo.ts
+++ b/packages/indexer-database/src/entities/RelayHashInfo.ts
@@ -42,7 +42,7 @@ export class RelayHashInfo {
   @Column({ nullable: true })
   relayHash: string;
 
-  @Column({ nullable: true })
+  @Column()
   internalHash: string;
 
   @Column({ type: "decimal" })

--- a/packages/indexer-database/src/entities/evm/FilledV3Relay.ts
+++ b/packages/indexer-database/src/entities/evm/FilledV3Relay.ts
@@ -16,8 +16,8 @@ export class FilledV3Relay {
   @Column({ nullable: true })
   relayHash?: string;
 
-  @Column({ nullable: true })
-  internalHash?: string;
+  @Column()
+  internalHash: string;
 
   @Column({ type: "decimal" })
   depositId: string;

--- a/packages/indexer-database/src/entities/evm/RequestedV3SlowFill.ts
+++ b/packages/indexer-database/src/entities/evm/RequestedV3SlowFill.ts
@@ -15,8 +15,8 @@ export class RequestedV3SlowFill {
   @Column({ nullable: true })
   relayHash?: string;
 
-  @Column({ nullable: true })
-  internalHash?: string;
+  @Column()
+  internalHash: string;
 
   @Column({ type: "decimal" })
   depositId: string;

--- a/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
+++ b/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
@@ -67,8 +67,8 @@ export class V3FundsDeposited {
   @Column({ nullable: true })
   messageHash?: string;
 
-  @Column({ nullable: true })
-  internalHash?: string;
+  @Column()
+  internalHash: string;
 
   @Column()
   exclusiveRelayer: string;

--- a/packages/indexer-database/src/migrations/1739306949453-InternalHashNotNull.ts
+++ b/packages/indexer-database/src/migrations/1739306949453-InternalHashNotNull.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class InternalHashNotNull1739306949453 implements MigrationInterface {
+  name = "InternalHashNotNull1739306949453";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."v3_funds_deposited" ALTER COLUMN "internalHash" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."filled_v3_relay" ALTER COLUMN "internalHash" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."requested_v3_slow_fill" ALTER COLUMN "internalHash" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "relay_hash_info" DROP CONSTRAINT "UK_relayHashInfo_internalHash_depositEvent"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "relay_hash_info" ALTER COLUMN "internalHash" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "relay_hash_info" ADD CONSTRAINT "UK_relayHashInfo_internalHash_depositEvent" UNIQUE ("internalHash", "depositEventId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "relay_hash_info" DROP CONSTRAINT "UK_relayHashInfo_internalHash_depositEvent"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "relay_hash_info" ALTER COLUMN "internalHash" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "relay_hash_info" ADD CONSTRAINT "UK_relayHashInfo_internalHash_depositEvent" UNIQUE ("depositEventId", "internalHash")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."requested_v3_slow_fill" ALTER COLUMN "internalHash" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."filled_v3_relay" ALTER COLUMN "internalHash" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."v3_funds_deposited" ALTER COLUMN "internalHash" DROP NOT NULL`,
+    );
+  }
+}


### PR DESCRIPTION
We set 'internalHash' as nullable so we could run the migrations in this PR: https://github.com/across-protocol/indexer/pull/178
It can be set as not nullable now. I've checked that there are no null values for it in any of the tables.