### PR TITLE
fix: price columns type

### DIFF
--- a/packages/indexer-database/src/migrations/1739385066933-DecimalPriceColumns.ts
+++ b/packages/indexer-database/src/migrations/1739385066933-DecimalPriceColumns.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DecimalPriceColumns1739385066933 implements MigrationInterface {
+  name = "DecimalPriceColumns1739385066933";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "relay_hash_info" ALTER COLUMN "bridgeFeeUsd" TYPE numeric`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "relay_hash_info" ALTER COLUMN "inputPriceUsd" TYPE numeric`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "relay_hash_info" ALTER COLUMN "outputPriceUsd" TYPE numeric`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "historic_price" ALTER COLUMN "price" TYPE numeric`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "relay_hash_info" ALTER COLUMN "bridgeFeeUsd" TYPE double precision`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "relay_hash_info" ALTER COLUMN "inputPriceUsd" TYPE double precision`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "relay_hash_info" ALTER COLUMN "outputPriceUsd" TYPE double precision`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "historic_price" ALTER COLUMN "price" TYPE double precision`,
+    );
+  }
+}


### PR DESCRIPTION
Type was set to 'double precision' in the migrations from this PR: https://github.com/across-protocol/indexer/pull/138 but the entity type is 'decimal'. This was causing a new migration recreating the columns being created.
To fix it, we are modifying the type column from 'double precision' to 'numeric'.