### PR TITLE
fix(bundle-service): remove unneeded error condition

### DIFF
--- a/packages/indexer/src/services/bundles.ts
+++ b/packages/indexer/src/services/bundles.ts
@@ -197,14 +197,7 @@ async function assignExecutionsToBundle(
             logIndex,
           );
         if (!proposedBundle) {
-          logger.error({
-            at: "Indexer#BundleEventsProcessor#assignExecutionsToBundle",
-            message: "Unable to find a proposed bundle for the given execution",
-            executionId: id,
-          });
-          throw new Error(
-            `Unable to find a proposed bundle for the given execution ${id}`,
-          );
+          return undefined;
         }
         return {
           bundleId: proposedBundle.bundle.id,
@@ -214,9 +207,14 @@ async function assignExecutionsToBundle(
     ),
   );
 
+  const validMappingOfExecutionsToBundles = mappingOfExecutionsToBundles.filter(
+    (mapping): mapping is { bundleId: number; executionId: number } =>
+      mapping !== undefined,
+  );
+
   const insertResults =
     await dbRepository.associateRootBundleExecutedEventsToBundle(
-      mappingOfExecutionsToBundles,
+      validMappingOfExecutionsToBundles,
     );
 
   logResultOfAssignment(


### PR DESCRIPTION
This error condition rarely appears as it will only happen when a database is fresh and an unlucky race condition occurs where the `BundleEventsProcessor` is fired before enough data is available. In all other `assign{}ToBundle` functions we ignore this case, but in the `assignExecutionsToBundle` we throw an error. I believe this is unwarranted as we gracefully ignore and re-process the failing event on the next loop until enough data is available.