### PR TITLE
fix: log error object

### DIFF
--- a/packages/indexer/src/data-indexing/service/Indexer.ts
+++ b/packages/indexer/src/data-indexing/service/Indexer.ts
@@ -92,7 +92,8 @@ export class Indexer {
           notificationPath: "across-indexer-error",
           blockRangeResult,
           dataIdentifier: this.dataHandler.getDataIdentifier(),
-          error: JSON.stringify(error),
+          error,
+          errorJson: JSON.stringify(error),
         });
         blockRangeProcessedSuccessfully = false;
       } finally {


### PR DESCRIPTION
I've seen cases when JSON.stringify() returns an empty object `{}`. I think in these cases we can benefit from printing the raw error instance too 