### PR TITLE
fix: api response for unsafe deposits

### DIFF
--- a/packages/indexer-api/src/dtos/deposits.dto.ts
+++ b/packages/indexer-api/src/dtos/deposits.dto.ts
@@ -27,7 +27,7 @@ export const DepositsParams = s.object({
 export type DepositsParams = s.Infer<typeof DepositsParams>;
 
 export const DepositParams = s.object({
-  depositId: s.optional(stringToInt),
+  depositId: s.optional(s.string()),
   originChainId: s.optional(stringToInt),
   depositTxHash: s.optional(s.string()),
   relayDataHash: s.optional(s.string()),


### PR DESCRIPTION
I noticed the API was unable to return the status for unsafe deposits. For example, this call:
https://dev.indexer.api.across.to/deposit/status?depositId=30566953172288618130184021794983800888451322878219651151031818372752299500678&originChainId=42161
Is returning:
```
{
    "error": "DepositNotFoundException",
    "message": "Deposit not found given the provided constraints"
}
```
But we do have the deposit in the database.
The issue is that superstruct parsing is truncating `depositId` as it is bigger than max int supported by js.
Right now it is parsing the params as:
```
{ depositId: 3.056695317228862e+76, originChainId: 42161, index: 0 }
```
After this change they are being parsed as:
```
{
  depositId: '30566953172288618130184021794983800888451322878219651151031818372752299500678',
  originChainId: 42161,
  index: 0
}
```