### PR TITLE
feat(svm): svm indexer data handler and solana constants

### DIFF
--- a/packages/indexer/src/data-indexing/service/SvmSpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SvmSpokePoolIndexerDataHandler.ts
@@ -1,0 +1,130 @@
+import { Logger } from "winston";
+import * as across from "@across-protocol/sdk";
+import {
+  getDeployedAddress,
+  getDeployedBlockNumber,
+  SvmSpokeClient,
+} from "@across-protocol/contracts";
+
+import { BlockRange } from "../model";
+import { IndexerDataHandler } from "./IndexerDataHandler";
+
+import { getMaxBlockLookBack } from "../../web3/constants";
+import { RedisCache } from "../../redis/redisCache";
+import { SvmProvider } from "../../web3/RetryProvidersFactory";
+
+export type FetchEventsResult = {
+  depositEvents: any; // TODO: fix type. Needs SDK changes
+  fillEvents: any; // TODO: fix type. Needs SDK changes
+};
+
+export class SvmSpokePoolIndexerDataHandler implements IndexerDataHandler {
+  constructor(
+    private logger: Logger,
+    private chainId: number,
+    private redisCache: RedisCache,
+    private hubPoolChainId: number,
+    private provider: SvmProvider,
+  ) {}
+
+  public getDataIdentifier() {
+    return `${getDeployedAddress("SvmSpoke", this.chainId)}:${this.chainId}`;
+  }
+
+  public getStartIndexingBlockNumber() {
+    return getDeployedBlockNumber("SvmSpoke", this.chainId);
+  }
+
+  public async processBlockRange(
+    blockRange: BlockRange,
+    lastFinalisedBlock: number,
+    isBackfilling: boolean = false,
+  ) {
+    this.logger.debug({
+      at: "Indexer#SvmSpokePoolIndexerDataHandler#processBlockRange",
+      message: `Processing block range ${this.getDataIdentifier()}`,
+      blockRange,
+      lastFinalisedBlock,
+      isBackfilling,
+    });
+
+    const events = await this.fetchEventsByRange(blockRange, isBackfilling);
+
+    this.logger.debug({
+      at: "Indexer#SpokePoolIndexerDataHandler#processBlockRange",
+      message: `Found events for ${this.getDataIdentifier()}`,
+      events: {
+        depositEvents: events.depositEvents.length,
+      },
+      blockRange,
+    });
+
+    // TODO:
+    // - store events
+    // - get block times
+    // - delete unfinalised events
+    // - update new deposits with integrator id
+    // - process events
+    // - publish price messages
+  }
+
+  private async fetchEventsByRange(
+    blockRange: BlockRange,
+    isBackfilling: boolean,
+  ): Promise<FetchEventsResult> {
+    // NOTE: maxBlockLookback is not a supported config in the svm client. Add when supported.
+    // If we are in a backfilling state then we should grab the largest
+    // lookback available to us. Otherwise, for this specific indexer we
+    // only need exactly what we're looking for, plus some padding to be sure
+    const maxBlockLookback = isBackfilling
+      ? getMaxBlockLookBack(this.chainId)
+      : Math.min(
+          getMaxBlockLookBack(this.chainId),
+          (blockRange.to - blockRange.from) * 2,
+        );
+
+    const spokePoolClient = await across.svm.SvmSpokeEventsClient.create(
+      this.provider,
+    );
+    // NOTE: svm spoke client uses bigint
+    const fromSlot = BigInt(blockRange.from);
+    const toSlot = BigInt(blockRange.to);
+
+    const depositEvents =
+      await spokePoolClient.queryEvents<SvmSpokeClient.FundsDeposited>(
+        "FundsDeposited",
+        fromSlot,
+        toSlot,
+      );
+    const fillEvents =
+      await spokePoolClient.queryEvents<SvmSpokeClient.FilledRelay>(
+        "FilledRelay",
+        fromSlot,
+        toSlot,
+      );
+
+    // NOTE: we can log events for now as it should be a short list
+    if (depositEvents.length > 0) {
+      this.logger.debug({
+        at: "Indexer#SvmSpokePoolIndexerDataHandler#processBlockRange",
+        message: `Found deposit events for ${this.getDataIdentifier()}`,
+        depositEvents,
+        blockRange,
+      });
+    }
+
+    if (fillEvents.length > 0) {
+      this.logger.debug({
+        at: "Indexer#SvmSpokePoolIndexerDataHandler#processBlockRange",
+        message: `Found fill events for ${this.getDataIdentifier()}`,
+        fillEvents,
+        blockRange,
+      });
+    }
+
+    return {
+      depositEvents,
+      fillEvents,
+    };
+  }
+}

--- a/packages/indexer/src/data-indexing/service/SvmSpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SvmSpokePoolIndexerDataHandler.ts
@@ -10,7 +10,6 @@ import { BlockRange } from "../model";
 import { IndexerDataHandler } from "./IndexerDataHandler";
 
 import { getMaxBlockLookBack } from "../../web3/constants";
-import { RedisCache } from "../../redis/redisCache";
 import { SvmProvider } from "../../web3/RetryProvidersFactory";
 
 export type FetchEventsResult = {
@@ -22,7 +21,6 @@ export class SvmSpokePoolIndexerDataHandler implements IndexerDataHandler {
   constructor(
     private logger: Logger,
     private chainId: number,
-    private redisCache: RedisCache,
     private hubPoolChainId: number,
     private provider: SvmProvider,
   ) {}

--- a/packages/indexer/src/data-indexing/service/constants.ts
+++ b/packages/indexer/src/data-indexing/service/constants.ts
@@ -2,6 +2,7 @@ import { CHAIN_IDs } from "@across-protocol/constants";
 
 // taken from https://github.com/UMAprotocol/bot-configs/blob/ed878f5f80509ad4ca55c8200e40670ba50e3b26/serverless-bots/across-v2-bot-config.json#L330C1-L342C25
 const finalisedBlockBufferDistances: Record<number, number> = {
+  // Mainnets
   [CHAIN_IDs.ALEPH_ZERO]: 80,
   [CHAIN_IDs.ARBITRUM]: 240,
   [CHAIN_IDs.BASE]: 60,
@@ -15,6 +16,7 @@ const finalisedBlockBufferDistances: Record<number, number> = {
   [CHAIN_IDs.POLYGON]: 128,
   [CHAIN_IDs.REDSTONE]: 60,
   [CHAIN_IDs.SCROLL]: 40,
+  [CHAIN_IDs.SOLANA]: 40,
   [CHAIN_IDs.SONEIUM]: 60,
   [CHAIN_IDs.UNICHAIN]: 60,
   [CHAIN_IDs.WORLD_CHAIN]: 60,
@@ -22,6 +24,8 @@ const finalisedBlockBufferDistances: Record<number, number> = {
   [CHAIN_IDs.ZORA]: 60,
   // BOBA is disabled
   [CHAIN_IDs.BOBA]: 0,
+  // Testnets:
+  [CHAIN_IDs.SOLANA_DEVNET]: 40,
 };
 
 export function getFinalisedBlockBufferDistance(chainId: number) {
@@ -37,6 +41,7 @@ export function getFinalisedBlockBufferDistance(chainId: number) {
 }
 
 const loopWaitTimeSeconds: Record<number, number> = {
+  // Mainnets
   [CHAIN_IDs.ALEPH_ZERO]: 2,
   [CHAIN_IDs.ARBITRUM]: 2,
   [CHAIN_IDs.BASE]: 4,
@@ -50,6 +55,7 @@ const loopWaitTimeSeconds: Record<number, number> = {
   [CHAIN_IDs.POLYGON]: 3,
   [CHAIN_IDs.REDSTONE]: 4,
   [CHAIN_IDs.SCROLL]: 6,
+  [CHAIN_IDs.SOLANA]: 2,
   [CHAIN_IDs.SONEIUM]: 4,
   [CHAIN_IDs.UNICHAIN]: 4,
   [CHAIN_IDs.WORLD_CHAIN]: 4,
@@ -57,6 +63,8 @@ const loopWaitTimeSeconds: Record<number, number> = {
   [CHAIN_IDs.ZORA]: 4,
   // BOBA is disabled
   [CHAIN_IDs.BOBA]: 0,
+  // Testnets:
+  [CHAIN_IDs.SOLANA_DEVNET]: 2,
 };
 
 export function getLoopWaitTimeSeconds(chainId: number) {

--- a/packages/indexer/src/redis/redisCache.ts
+++ b/packages/indexer/src/redis/redisCache.ts
@@ -13,7 +13,7 @@ export class RedisCache implements across.interfaces.CachingMechanismInterface {
     value: ObjectType,
     ttl?: number,
   ): Promise<string | undefined> {
-    if (ttl !== undefined) {
+    if (ttl !== undefined && ttl !== Number.POSITIVE_INFINITY) {
       return this.redis.set(key, JSON.stringify(value), "EX", ttl);
     }
     return this.redis.set(key, JSON.stringify(value));

--- a/packages/indexer/src/web3/RetryProvidersFactory.ts
+++ b/packages/indexer/src/web3/RetryProvidersFactory.ts
@@ -5,6 +5,12 @@ import { parseRetryProviderEnvs, parseProvidersUrls } from "../parseEnv";
 import { RedisCache } from "../redis/redisCache";
 import { getChainCacheFollowDistance } from "./constants";
 
+// SVM provider helper type.
+// TODO: move to SDK.
+export type SvmProvider = ReturnType<
+  typeof providers.CachedSolanaRpcFactory.prototype.createRpcClient
+>;
+
 export class RetryProvidersFactory {
   private retryProviders: Map<number, providers.RetryProvider> = new Map();
 

--- a/packages/indexer/src/web3/constants.ts
+++ b/packages/indexer/src/web3/constants.ts
@@ -53,6 +53,7 @@ export const CHAIN_CACHE_FOLLOW_DISTANCE: { [chainId: number]: number } = {
   [CHAIN_IDs.POLYGON]: 256,
   [CHAIN_IDs.REDSTONE]: 120,
   [CHAIN_IDs.SCROLL]: 100,
+  [CHAIN_IDs.SOLANA]: 80,
   [CHAIN_IDs.SONEIUM]: 120,
   [CHAIN_IDs.UNICHAIN]: 120,
   [CHAIN_IDs.WORLD_CHAIN]: 120,
@@ -68,6 +69,7 @@ export const CHAIN_CACHE_FOLLOW_DISTANCE: { [chainId: number]: number } = {
   [CHAIN_IDs.OPTIMISM_SEPOLIA]: 0,
   [CHAIN_IDs.POLYGON_AMOY]: 0,
   [CHAIN_IDs.SEPOLIA]: 0,
+  [CHAIN_IDs.SOLANA_DEVNET]: 80,
 };
 
 export const getChainCacheFollowDistance = (chainId: number) => {
@@ -106,6 +108,7 @@ export function getMaxBlockLookBack(chainId: number) {
 
 // Average block time in seconds by chain
 export const BLOCK_TIME_SECONDS: { [chainId: number]: number } = {
+  // Mainnets
   [CHAIN_IDs.ALEPH_ZERO]: 2,
   [CHAIN_IDs.ARBITRUM]: 0.25,
   [CHAIN_IDs.BASE]: 2,
@@ -120,11 +123,14 @@ export const BLOCK_TIME_SECONDS: { [chainId: number]: number } = {
   [CHAIN_IDs.POLYGON]: 2,
   [CHAIN_IDs.REDSTONE]: 2,
   [CHAIN_IDs.SCROLL]: 3,
+  [CHAIN_IDs.SOLANA]: 0.4,
   [CHAIN_IDs.SONEIUM]: 2,
   [CHAIN_IDs.UNICHAIN]: 2,
   [CHAIN_IDs.WORLD_CHAIN]: 2,
   [CHAIN_IDs.ZK_SYNC]: 1,
   [CHAIN_IDs.ZORA]: 2,
+  // Testnets:
+  [CHAIN_IDs.SOLANA_DEVNET]: 0.4,
 };
 
 /**


### PR DESCRIPTION
This PR:
- Adds Solana's constants.
- Adds a new `SvmSpokePoolIndexerDataHandler ` class that instantiates the svm spoke client to fetch and return events. This class will be used in other upcoming PRs.
