### PR TITLE
feat(providersFactory): support svm providers

### DIFF
--- a/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
+++ b/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
@@ -83,7 +83,9 @@ export class AcrossIndexerManager {
         ),
       },
       hubPoolIndexerDataHandler,
-      this.retryProvidersFactory.getProviderForChainId(this.config.hubChainId),
+      this.retryProvidersFactory.getProviderForChainId(
+        this.config.hubChainId,
+      ) as across.providers.RetryProvider,
       this.logger,
       this.postgres,
     );
@@ -98,7 +100,9 @@ export class AcrossIndexerManager {
           this.logger,
           chainId,
           this.config.hubChainId,
-          this.retryProvidersFactory.getProviderForChainId(chainId),
+          this.retryProvidersFactory.getProviderForChainId(
+            chainId,
+          ) as across.providers.RetryProvider,
           this.configStoreClientFactory,
           this.hubPoolClientFactory,
           this.spokePoolClientFactory,
@@ -120,7 +124,9 @@ export class AcrossIndexerManager {
             maxBlockRangeSize: this.config.maxBlockRangeSize,
           },
           spokePoolIndexerDataHandler,
-          this.retryProvidersFactory.getProviderForChainId(chainId),
+          this.retryProvidersFactory.getProviderForChainId(
+            chainId,
+          ) as across.providers.RetryProvider,
           this.logger,
           this.postgres,
         );

--- a/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
+++ b/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
@@ -1,5 +1,5 @@
 import { Logger } from "winston";
-
+import * as across from "@across-protocol/sdk";
 import { DataSource } from "@repo/indexer-database";
 import { eventProcessorManager } from "@repo/webhooks";
 

--- a/packages/indexer/src/messaging/IntegratorIdWorker.ts
+++ b/packages/indexer/src/messaging/IntegratorIdWorker.ts
@@ -1,6 +1,7 @@
 import Redis from "ioredis";
 import winston from "winston";
 import { Job, Worker } from "bullmq";
+import { providers } from "@across-protocol/sdk";
 import { DataSource, entities } from "@repo/indexer-database";
 import { IndexerQueues } from "./service";
 import { getIntegratorId } from "../utils";
@@ -70,7 +71,7 @@ export class IntegratorIdWorker {
       deposit.originChainId,
     );
     const integratorId = await getIntegratorId(
-      provider,
+      provider as providers.RetryProvider,
       deposit.quoteTimestamp,
       deposit.transactionHash,
     );

--- a/packages/indexer/src/parseEnv.ts
+++ b/packages/indexer/src/parseEnv.ts
@@ -26,7 +26,20 @@ export type RedisConfig = {
   port: number;
   maxRetriesPerRequest: null;
 };
+
 export type ProviderConfig = [providerUrl: string, chainId: number];
+
+export type RetryProviderConfig = {
+  providerCacheNamespace: string;
+  maxConcurrency: number;
+  pctRpcCallsLogged: number;
+  standardTtlBlockDistance?: number;
+  noTtlBlockDistance: number;
+  providerCacheTtl?: number;
+  nodeQuorumThreshold: number;
+  retries: number;
+  retryDelay: number;
+};
 
 export type Env = Record<string, string | undefined>;
 
@@ -108,7 +121,7 @@ export function parseProvidersUrls() {
   return results;
 }
 
-export function parseRetryProviderEnvs(chainId: number) {
+export function parseRetryProviderEnvs(chainId: number): RetryProviderConfig {
   const providerCacheNamespace =
     process.env.PROVIDER_CACHE_NAMESPACE || "indexer_provider_cache";
   const maxConcurrency = Number(

--- a/packages/indexer/src/services/BundleBuilderService.ts
+++ b/packages/indexer/src/services/BundleBuilderService.ts
@@ -1,4 +1,10 @@
-import { caching, clients, typechain, utils } from "@across-protocol/sdk";
+import {
+  caching,
+  clients,
+  typechain,
+  utils,
+  providers,
+} from "@across-protocol/sdk";
 import { entities } from "@repo/indexer-database";
 import { assert } from "@repo/error-handling";
 import Redis from "ioredis";
@@ -117,9 +123,10 @@ export class BundleBuilderService extends BaseIndexer {
   private async isCloseEnoughToHead(
     lastExecutedBundle: entities.ProposedRootBundle,
   ) {
-    const currentMainnetBlock = await this.config.providerFactory
-      .getProviderForChainId(this.config.hubChainId)
-      .getBlockNumber();
+    const provider = this.config.providerFactory.getProviderForChainId(
+      this.config.hubChainId,
+    ) as providers.RetryProvider;
+    const currentMainnetBlock = await provider.getBlockNumber();
     const lastExecutedMainnetBlock =
       lastExecutedBundle.bundleEvaluationBlockNumbers[0]!;
     const distanceToHead = currentMainnetBlock - lastExecutedMainnetBlock;

--- a/packages/indexer/src/utils/bundleBuilderUtils.ts
+++ b/packages/indexer/src/utils/bundleBuilderUtils.ts
@@ -1,4 +1,4 @@
-import { utils, clients, interfaces } from "@across-protocol/sdk";
+import { utils, clients, interfaces, providers } from "@across-protocol/sdk";
 import winston from "winston";
 import { entities } from "@repo/indexer-database";
 import { BundleRepository } from "../database/BundleRepository";
@@ -134,7 +134,9 @@ export async function getBlockRangeFromBundleToHead(
       if (disabledChainIds.includes(chainId)) {
         return { chainId, startBlock: previousBlock, endBlock: previousBlock };
       } else {
-        const provider = providers.getProviderForChainId(chainId);
+        const provider = providers.getProviderForChainId(
+          chainId,
+        ) as providers.RetryProvider;
         const currentBlock = await provider.getBlockNumber();
         return {
           chainId,

--- a/packages/indexer/src/utils/contractFactoryUtils.ts
+++ b/packages/indexer/src/utils/contractFactoryUtils.ts
@@ -1,5 +1,5 @@
 import { CHAIN_IDs } from "@across-protocol/constants";
-import { clients } from "@across-protocol/sdk";
+import { clients, providers } from "@across-protocol/sdk";
 import { Logger } from "winston";
 import { getMaxBlockLookBack } from "../web3/constants";
 import { RetryProvidersFactory } from "../web3/RetryProvidersFactory";
@@ -51,7 +51,9 @@ export class ConfigStoreClientFactory extends ContractClientFactory<clients.Acro
     // FIXME: hardcoded chain id to represent mainnet
     const chainId = CHAIN_IDs.MAINNET;
 
-    const provider = this.retryProviderFactory.getProviderForChainId(chainId);
+    const provider = this.retryProviderFactory.getProviderForChainId(
+      chainId,
+    ) as providers.RetryProvider;
     return getConfigStoreClient({
       provider,
       logger: this.logger,
@@ -98,7 +100,9 @@ export class HubPoolClientFactory extends ContractClientFactory<
         toBlock,
       );
     return getHubPoolClient({
-      provider: this.retryProviderFactory.getProviderForChainId(chainId),
+      provider: this.retryProviderFactory.getProviderForChainId(
+        chainId,
+      ) as providers.RetryProvider,
       logger: this.logger,
       maxBlockLookBack: getMaxBlockLookBack(chainId),
       chainId,
@@ -149,7 +153,9 @@ export class SpokePoolClientFactory extends ContractClientFactory<
       overrides?.maxBlockLookback ?? getMaxBlockLookBack(chainId);
 
     return getSpokeClient({
-      provider: this.retryProviderFactory.getProviderForChainId(chainId),
+      provider: this.retryProviderFactory.getProviderForChainId(
+        chainId,
+      ) as providers.RetryProvider,
       logger: this.logger,
       maxBlockLookBack,
       chainId,

--- a/packages/indexer/src/utils/contractUtils.ts
+++ b/packages/indexer/src/utils/contractUtils.ts
@@ -176,42 +176,4 @@ export function getHubPoolClient(
   );
 }
 
-export type RetryProviderConfig = {
-  providerCacheNamespace: string;
-  maxConcurrency: number;
-  pctRpcCallsLogged: number;
-  standardTtlBlockDistance: number;
-  noTtlBlockDistance: number;
-  providerCacheTtl: number;
-  nodeQuorumThreshold: number;
-  retries: number;
-  delay: number;
-  providerConfigs: [providerUrls: string, chainId: number][];
-  chainId: number;
-};
-export type RetryProviderDeps = {
-  cache: across.interfaces.CachingMechanismInterface;
-  logger: winston.Logger;
-};
-
-export function getRetryProvider(
-  params: RetryProviderConfig & RetryProviderDeps,
-) {
-  return new across.providers.RetryProvider(
-    params.providerConfigs,
-    params.chainId,
-    params.nodeQuorumThreshold,
-    params.retries,
-    params.delay,
-    params.maxConcurrency,
-    params.providerCacheNamespace,
-    params.pctRpcCallsLogged,
-    params.cache,
-    params.standardTtlBlockDistance,
-    params.noTtlBlockDistance,
-    params.providerCacheTtl,
-    params.logger,
-  );
-}
-
 export const BN_ZERO = across.utils.bnZero;

--- a/packages/indexer/src/web3/RetryProvidersFactory.ts
+++ b/packages/indexer/src/web3/RetryProvidersFactory.ts
@@ -1,4 +1,5 @@
 import { Logger } from "winston";
+import { PUBLIC_NETWORKS } from "@across-protocol/constants";
 import { providers, utils } from "@across-protocol/sdk";
 
 import {
@@ -40,12 +41,16 @@ export class RetryProvidersFactory {
           retryProviderEnvs,
           providerUrls,
         );
-      } else {
-        // explicitly check for evm
+      } else if (utils.chainIsEvm(chainId)) {
         provider = this.instantiateEvmProvider(
           chainId,
           { ...retryProviderEnvs, standardTtlBlockDistance },
           providerUrls,
+        );
+      } else {
+        const chainFamily = PUBLIC_NETWORKS[chainId]?.family;
+        throw new Error(
+          `Invalid chainId ${chainId}. Chain family ${chainFamily} not supported.`,
         );
       }
 

--- a/packages/indexer/src/web3/RetryProvidersFactory.ts
+++ b/packages/indexer/src/web3/RetryProvidersFactory.ts
@@ -1,7 +1,11 @@
 import { Logger } from "winston";
-import { providers } from "@across-protocol/sdk";
+import { providers, utils } from "@across-protocol/sdk";
 
-import { parseRetryProviderEnvs, parseProvidersUrls } from "../parseEnv";
+import {
+  parseRetryProviderEnvs,
+  parseProvidersUrls,
+  RetryProviderConfig,
+} from "../parseEnv";
 import { RedisCache } from "../redis/redisCache";
 import { getChainCacheFollowDistance } from "./constants";
 
@@ -12,7 +16,8 @@ export type SvmProvider = ReturnType<
 >;
 
 export class RetryProvidersFactory {
-  private retryProviders: Map<number, providers.RetryProvider> = new Map();
+  private retryProviders: Map<number, SvmProvider | providers.RetryProvider> =
+    new Map();
 
   constructor(
     private redisCache: RedisCache,
@@ -28,27 +33,69 @@ export class RetryProvidersFactory {
         throw new Error(`Invalid provider urls found for chainId: ${chainId}`);
       }
       const standardTtlBlockDistance = getChainCacheFollowDistance(chainId);
-      const provider = new providers.RetryProvider(
-        providerUrls.map((url) => [url, chainId]),
-        chainId,
-        retryProviderEnvs.nodeQuorumThreshold,
-        retryProviderEnvs.retries,
-        retryProviderEnvs.retryDelay,
-        retryProviderEnvs.maxConcurrency,
-        retryProviderEnvs.providerCacheNamespace,
-        retryProviderEnvs.pctRpcCallsLogged,
-        this.redisCache,
-        standardTtlBlockDistance,
-        retryProviderEnvs.noTtlBlockDistance,
-        retryProviderEnvs.providerCacheTtl,
-        this.logger,
-      );
+      let provider;
+      if (utils.chainIsSvm(chainId)) {
+        provider = this.instantiateSvmProvider(
+          chainId,
+          retryProviderEnvs,
+          providerUrls,
+        );
+      } else {
+        // explicitly check for evm
+        provider = this.instantiateEvmProvider(
+          chainId,
+          { ...retryProviderEnvs, standardTtlBlockDistance },
+          providerUrls,
+        );
+      }
+
       this.retryProviders.set(chainId, provider);
     }
     return this;
   }
 
-  public getProviderForChainId(chainId: number) {
+  private instantiateSvmProvider(
+    chainId: number,
+    providerEnvs: RetryProviderConfig,
+    providerUrls: string[],
+  ): SvmProvider {
+    const rpcFactory = new providers.CachedSolanaRpcFactory(
+      providerEnvs.providerCacheNamespace,
+      this.redisCache,
+      providerEnvs.maxConcurrency,
+      providerEnvs.pctRpcCallsLogged,
+      this.logger,
+      providerUrls[0]!,
+      chainId,
+    );
+    return rpcFactory.createRpcClient();
+  }
+
+  private instantiateEvmProvider(
+    chainId: number,
+    providerEnvs: RetryProviderConfig,
+    providerUrls: string[],
+  ): providers.RetryProvider {
+    return new providers.RetryProvider(
+      providerUrls.map((url) => [url, chainId]),
+      chainId,
+      providerEnvs.nodeQuorumThreshold,
+      providerEnvs.retries,
+      providerEnvs.retryDelay,
+      providerEnvs.maxConcurrency,
+      providerEnvs.providerCacheNamespace,
+      providerEnvs.pctRpcCallsLogged,
+      this.redisCache,
+      providerEnvs.standardTtlBlockDistance,
+      providerEnvs.noTtlBlockDistance,
+      providerEnvs.providerCacheTtl,
+      this.logger,
+    );
+  }
+
+  public getProviderForChainId(
+    chainId: number,
+  ): SvmProvider | providers.RetryProvider {
     const retryProvider = this.retryProviders.get(chainId);
 
     if (!retryProvider) {


### PR DESCRIPTION
This PR modifies the `retryProvidersFactory` so it is able to instantiate both EVM and SVM providers based on the 'family' of the provided chain. For SVM, it will instantiate cached providers.