### PR TITLE
feat: add unfilled deposits

### DIFF
--- a/packages/indexer-api/src/controllers/deposits.ts
+++ b/packages/indexer-api/src/controllers/deposits.ts
@@ -1,7 +1,11 @@
 import { Request, Response, NextFunction } from "express";
 import * as s from "superstruct";
 import { DepositsService } from "../services/deposits";
-import { DepositsParams, DepositParams } from "../dtos/deposits.dto";
+import {
+  DepositsParams,
+  DepositParams,
+  UnfilledDepositsParams,
+} from "../dtos/deposits.dto";
 
 export class DepositsController {
   constructor(private service: DepositsService) {}
@@ -28,6 +32,20 @@ export class DepositsController {
     try {
       const params = s.create(req.query, DepositParams);
       const result = await this.service.getDepositStatus(params);
+      return res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  };
+
+  public getUnfilledDeposits = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    try {
+      const params = s.create(req.query, UnfilledDepositsParams);
+      const result = await this.service.getUnfilledDeposits(params);
       return res.json(result);
     } catch (err) {
       next(err);

--- a/packages/indexer-api/src/dtos/deposits.dto.ts
+++ b/packages/indexer-api/src/dtos/deposits.dto.ts
@@ -39,3 +39,13 @@ export const DepositParams = s.object({
 });
 
 export type DepositParams = s.Infer<typeof DepositParams>;
+
+export const UnfilledDepositsParams = s.object({
+  originChainId: s.optional(stringToInt),
+  destinationChainId: s.optional(stringToInt),
+  startTimestamp: s.optional(stringToInt),
+  endTimestamp: s.optional(stringToInt),
+  minPendingSeconds: s.optional(stringToInt),
+});
+
+export type UnfilledDepositsParams = s.Infer<typeof UnfilledDepositsParams>;

--- a/packages/indexer-api/src/dtos/deposits.dto.ts
+++ b/packages/indexer-api/src/dtos/deposits.dto.ts
@@ -46,7 +46,7 @@ export const UnfilledDepositsParams = s.object({
   startTimestamp: s.optional(stringToInt),
   endTimestamp: s.optional(stringToInt),
   minPendingSeconds: s.optional(stringToInt),
-  skip: s.optional(stringToInt),
+  skip: s.defaulted(stringToInt, 0),
   limit: s.defaulted(stringToInt, 50),
 });
 

--- a/packages/indexer-api/src/dtos/deposits.dto.ts
+++ b/packages/indexer-api/src/dtos/deposits.dto.ts
@@ -46,6 +46,8 @@ export const UnfilledDepositsParams = s.object({
   startTimestamp: s.optional(stringToInt),
   endTimestamp: s.optional(stringToInt),
   minPendingSeconds: s.optional(stringToInt),
+  skip: s.optional(stringToInt),
+  limit: s.defaulted(stringToInt, 50),
 });
 
 export type UnfilledDepositsParams = s.Infer<typeof UnfilledDepositsParams>;

--- a/packages/indexer-api/src/routers/deposits.ts
+++ b/packages/indexer-api/src/routers/deposits.ts
@@ -10,5 +10,6 @@ export function getRouter(db: DataSource, redis: Redis): Router {
   const controller = new DepositsController(service);
   router.get("/deposits", controller.getDeposits);
   router.get("/deposit/status", controller.getDepositStatus);
+  router.get("/deposit/unfilled", controller.getUnfilledDeposits);
   return router;
 }

--- a/packages/indexer-api/src/routers/deposits.ts
+++ b/packages/indexer-api/src/routers/deposits.ts
@@ -10,6 +10,6 @@ export function getRouter(db: DataSource, redis: Redis): Router {
   const controller = new DepositsController(service);
   router.get("/deposits", controller.getDeposits);
   router.get("/deposit/status", controller.getDepositStatus);
-  router.get("/deposit/unfilled", controller.getUnfilledDeposits);
+  router.get("/deposits/unfilled", controller.getUnfilledDeposits);
   return router;
 }

--- a/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
+++ b/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
@@ -22,8 +22,6 @@ import {
   "logIndex",
 ])
 @Index("IX_v3FundsDeposited_blockTimestamp", ["blockTimestamp"])
-@Index("IX_v3FundsDeposited_originChainId", ["originChainId"])
-@Index("IX_v3FundsDeposited_destinationChainId", ["destinationChainId"])
 export class V3FundsDeposited {
   @PrimaryGeneratedColumn()
   id: number;

--- a/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
+++ b/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
@@ -21,6 +21,9 @@ import {
   "originChainId",
   "logIndex",
 ])
+@Index("IX_v3FundsDeposited_blockTimestamp", ["blockTimestamp"])
+@Index("IX_v3FundsDeposited_originChainId", ["originChainId"])
+@Index("IX_v3FundsDeposited_destinationChainId", ["destinationChainId"])
 export class V3FundsDeposited {
   @PrimaryGeneratedColumn()
   id: number;

--- a/packages/indexer-database/src/migrations/1742571428156-V3DepositIndexes.ts
+++ b/packages/indexer-database/src/migrations/1742571428156-V3DepositIndexes.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Migrations1742571428156 implements MigrationInterface {
+  name = "Migrations1742571428156";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IX_v3FundsDeposited_destinationChainId" ON "evm"."v3_funds_deposited" ("destinationChainId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IX_v3FundsDeposited_originChainId" ON "evm"."v3_funds_deposited" ("originChainId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IX_v3FundsDeposited_blockTimestamp" ON "evm"."v3_funds_deposited" ("blockTimestamp") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "evm"."IX_v3FundsDeposited_blockTimestamp"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "evm"."IX_v3FundsDeposited_originChainId"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "evm"."IX_v3FundsDeposited_destinationChainId"`,
+    );
+  }
+}

--- a/packages/indexer-database/src/migrations/1742571428156-V3DepositIndexes.ts
+++ b/packages/indexer-database/src/migrations/1742571428156-V3DepositIndexes.ts
@@ -5,12 +5,6 @@ export class Migrations1742571428156 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE INDEX "IX_v3FundsDeposited_destinationChainId" ON "evm"."v3_funds_deposited" ("destinationChainId") `,
-    );
-    await queryRunner.query(
-      `CREATE INDEX "IX_v3FundsDeposited_originChainId" ON "evm"."v3_funds_deposited" ("originChainId") `,
-    );
-    await queryRunner.query(
       `CREATE INDEX "IX_v3FundsDeposited_blockTimestamp" ON "evm"."v3_funds_deposited" ("blockTimestamp") `,
     );
   }
@@ -18,12 +12,6 @@ export class Migrations1742571428156 implements MigrationInterface {
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `DROP INDEX "evm"."IX_v3FundsDeposited_blockTimestamp"`,
-    );
-    await queryRunner.query(
-      `DROP INDEX "evm"."IX_v3FundsDeposited_originChainId"`,
-    );
-    await queryRunner.query(
-      `DROP INDEX "evm"."IX_v3FundsDeposited_destinationChainId"`,
     );
   }
 }


### PR DESCRIPTION
# motivation
dart needs several new queries exposed, this is unfilled deposits

# changes
adds /deposit/unfilled with the following params:
```
export const UnfilledDepositsParams = s.object({
  originChainId: s.optional(stringToInt),
  destinationChainId: s.optional(stringToInt),
  startTimestamp: s.optional(stringToInt),
  endTimestamp: s.optional(stringToInt),
});
```

And returns a list of V3FundsDeposited

Please check that these queries look correct!

This is the original spec:

```
Unfilled deposit endpoint
The unfilled deposit endpoint should fetch a list of deposits that are yet to be filled.

Suggested endpoint: indexer.across.to/unfilled_deposits

Suggested arguments:
originChainId: Defaults to all chains
destinationChainId: Defaults to all chains
startTimestamp: Defaults to the timestamp from 5 minutes ago
endTimestamp: Defaults to current timestamp

Suggested return fields:
originChainId
destinationChainId
originBlockNumber
originDt
originTxHash
inputTokenAddress
inputTokenSymbol
outputTokenAddress
outputTokenSymbol
inputAmount
exclusiveRelayer
numSecondsPending 

This endpoint may need pagination as well
```


