### PR TITLE
fix: reduce initial update time of hubpool and config clients

### DIFF
--- a/packages/indexer/src/web3/constants.ts
+++ b/packages/indexer/src/web3/constants.ts
@@ -26,12 +26,11 @@ const DEFAULT_NO_TTL_DISTANCE: { [chainId: number]: number } = {
 };
 
 export function getNoTtlBlockDistance(chainId: number) {
-  return 1_000_000_000_000;
-  // const noTtlBlockDistance = DEFAULT_NO_TTL_DISTANCE[chainId];
-  // if (!noTtlBlockDistance) {
-  //   throw new Error(`No noTtlBlockDistance found for chainId: ${chainId}`);
-  // }
-  // return noTtlBlockDistance;
+  const noTtlBlockDistance = DEFAULT_NO_TTL_DISTANCE[chainId];
+  if (!noTtlBlockDistance) {
+    throw new Error(`No noTtlBlockDistance found for chainId: ${chainId}`);
+  }
+  return noTtlBlockDistance;
 }
 
 // This is the max anticipated distance on each chain before RPC data is likely to be consistent amongst providers.


### PR DESCRIPTION
This PR speeds up the hubpool and config clients update() function by leveraging correctly the Redis cache. During my local testing, the initial update from deployment block was reduced to ~25 seconds down from 200+ seconds