### PR TITLE
feat: add filled deposits endpoint

### DIFF
--- a/packages/indexer-api/src/controllers/deposits.ts
+++ b/packages/indexer-api/src/controllers/deposits.ts
@@ -4,7 +4,7 @@ import { DepositsService } from "../services/deposits";
 import {
   DepositsParams,
   DepositParams,
-  UnfilledDepositsParams,
+  FilterDepositsParams,
 } from "../dtos/deposits.dto";
 
 export class DepositsController {
@@ -44,8 +44,21 @@ export class DepositsController {
     next: NextFunction,
   ) => {
     try {
-      const params = s.create(req.query, UnfilledDepositsParams);
+      const params = s.create(req.query, FilterDepositsParams);
       const result = await this.service.getUnfilledDeposits(params);
+      return res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  };
+  public getFilledDeposits = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    try {
+      const params = s.create(req.query, FilterDepositsParams);
+      const result = await this.service.getFilledDeposits(params);
       return res.json(result);
     } catch (err) {
       next(err);

--- a/packages/indexer-api/src/dtos/deposits.dto.ts
+++ b/packages/indexer-api/src/dtos/deposits.dto.ts
@@ -21,7 +21,11 @@ export const DepositsParams = s.object({
   // some kind of pagination options, skip could be the start point
   skip: s.optional(stringToInt),
   // pagination limit, how many to return after the start, note we convert string to number
-  limit: s.defaulted(stringToInt, 50),
+  limit: s.refine(
+    s.defaulted(stringToInt, 50),
+    "maxLimit",
+    (value) => value <= 1000 || "Limit must not exceed 1000",
+  ),
 });
 
 export type DepositsParams = s.Infer<typeof DepositsParams>;
@@ -46,7 +50,11 @@ export const FilterDepositsParams = s.object({
   startTimestamp: s.optional(stringToInt),
   endTimestamp: s.optional(stringToInt),
   skip: s.defaulted(stringToInt, 0),
-  limit: s.defaulted(stringToInt, 50),
+  limit: s.refine(
+    s.defaulted(stringToInt, 50),
+    "maxLimit",
+    (value) => value <= 1000 || "Limit must not exceed 1000",
+  ),
   minSecondsToFill: s.optional(stringToInt),
 });
 

--- a/packages/indexer-api/src/dtos/deposits.dto.ts
+++ b/packages/indexer-api/src/dtos/deposits.dto.ts
@@ -40,14 +40,14 @@ export const DepositParams = s.object({
 
 export type DepositParams = s.Infer<typeof DepositParams>;
 
-export const UnfilledDepositsParams = s.object({
+export const FilterDepositsParams = s.object({
   originChainId: s.optional(stringToInt),
   destinationChainId: s.optional(stringToInt),
   startTimestamp: s.optional(stringToInt),
   endTimestamp: s.optional(stringToInt),
-  minPendingSeconds: s.optional(stringToInt),
   skip: s.defaulted(stringToInt, 0),
   limit: s.defaulted(stringToInt, 50),
+  minSecondsToFill: s.optional(stringToInt),
 });
 
-export type UnfilledDepositsParams = s.Infer<typeof UnfilledDepositsParams>;
+export type FilterDepositsParams = s.Infer<typeof FilterDepositsParams>;

--- a/packages/indexer-api/src/routers/deposits.ts
+++ b/packages/indexer-api/src/routers/deposits.ts
@@ -11,5 +11,6 @@ export function getRouter(db: DataSource, redis: Redis): Router {
   router.get("/deposits", controller.getDeposits);
   router.get("/deposit/status", controller.getDepositStatus);
   router.get("/deposits/unfilled", controller.getUnfilledDeposits);
+  router.get("/deposits/filled", controller.getFilledDeposits);
   return router;
 }

--- a/packages/indexer-api/src/services/deposits.ts
+++ b/packages/indexer-api/src/services/deposits.ts
@@ -3,13 +3,18 @@ import { DataSource, entities } from "@repo/indexer-database";
 import type {
   DepositParams,
   DepositsParams,
-  UnfilledDepositsParams,
+  FilterDepositsParams,
 } from "../dtos/deposits.dto";
 import {
   DepositNotFoundException,
   IncorrectQueryParamsException,
   IndexParamOutOfRangeException,
 } from "./exceptions";
+import {
+  FilledV3Relay,
+  RelayHashInfo,
+  V3FundsDeposited,
+} from "../../../indexer-database/dist/src/entities";
 
 type APIHandler = (
   params?: JSON,
@@ -189,7 +194,7 @@ export class DepositsService {
     return result;
   }
 
-  public async getUnfilledDeposits(params: UnfilledDepositsParams): Promise<
+  public async getUnfilledDeposits(params: FilterDepositsParams): Promise<
     Array<
       entities.V3FundsDeposited & {
         status: entities.RelayStatus;
@@ -202,8 +207,8 @@ export class DepositsService {
       destinationChainId,
       startTimestamp = Date.now() - 5 * 60 * 1000,
       endTimestamp = Date.now(),
-      skip = 0,
-      limit = 50,
+      skip,
+      limit,
     } = params;
 
     const startDate = new Date(startTimestamp);
@@ -241,6 +246,73 @@ export class DepositsService {
         {
           destinationChainId,
         },
+      );
+    }
+
+    queryBuilder.skip(skip);
+    queryBuilder.limit(limit);
+
+    return queryBuilder.execute();
+  }
+
+  public async getFilledDeposits(params: FilterDepositsParams) {
+    const {
+      originChainId,
+      destinationChainId,
+      startTimestamp = Date.now() - 5 * 60 * 1000,
+      endTimestamp = Date.now(),
+      skip,
+      limit,
+      minSecondsToFill,
+    } = params;
+
+    const startDate = new Date(startTimestamp);
+    const endDate = new Date(endTimestamp);
+
+    const repo = this.db.getRepository(entities.RelayHashInfo);
+    const queryBuilder = repo
+      .createQueryBuilder("rhi")
+      .leftJoinAndSelect(
+        entities.V3FundsDeposited,
+        "deposit",
+        "deposit.id = rhi.depositEventId",
+      )
+      .leftJoinAndSelect(
+        entities.FilledV3Relay,
+        "fill",
+        "fill.id = rhi.fillEventId",
+      )
+      .where("rhi.status = :status", { status: entities.RelayStatus.Filled })
+      .select([
+        "deposit.*", // Select all columns from depositEvent
+        "rhi.status as status", // Select status from RelayHashInfo
+        "fill.relayer as relayer", // Select relayer from FillEvent
+        "fill.blockTimestamp as fillBlockTimestamp", // Select blockTimestamp from fillEvent
+      ])
+      .andWhere("deposit.blockTimestamp BETWEEN :startDate AND :endDate", {
+        startDate,
+        endDate,
+      });
+
+    if (originChainId) {
+      queryBuilder.andWhere("deposit.originChainId = :originChainId", {
+        originChainId,
+      });
+    }
+
+    if (destinationChainId) {
+      queryBuilder.andWhere(
+        "deposit.destinationChainId = :destinationChainId",
+        {
+          destinationChainId,
+        },
+      );
+    }
+
+    if (minSecondsToFill !== undefined) {
+      queryBuilder.andWhere(
+        "EXTRACT(EPOCH FROM (fill.blockTimestamp - deposit.blockTimestamp)) >= :minSecondsToFill",
+        { minSecondsToFill },
       );
     }
 

--- a/packages/indexer-api/src/services/deposits.ts
+++ b/packages/indexer-api/src/services/deposits.ts
@@ -10,11 +10,6 @@ import {
   IncorrectQueryParamsException,
   IndexParamOutOfRangeException,
 } from "./exceptions";
-import {
-  FilledV3Relay,
-  RelayHashInfo,
-  V3FundsDeposited,
-} from "../../../indexer-database/dist/src/entities";
 
 type APIHandler = (
   params?: JSON,


### PR DESCRIPTION
# motivation
Add endpoint for dart to query recently filled deposits

# changes
This adds separate endpoint at deposits/filled, which returns deposit data + fill data for filled deposits only

This logic was not combined with unfilled because the data needed is slightly different.  i think its possible to combine all these calls but may make it a more complex than necessary