### PR TITLE
chore: add transaction hash to deposits unique constraint

### DIFF
--- a/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
+++ b/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
@@ -9,9 +9,10 @@ import {
 } from "typeorm";
 
 @Entity({ schema: "evm" })
-@Unique("UK_v3FundsDeposited_relayHash_block_logIdx", [
+@Unique("UK_FundsDeposited_relayHash_block_txnHash_logIdx", [
   "relayHash",
   "blockNumber",
+  "transactionHash",
   "logIndex",
 ])
 @Index("IX_v3FundsDeposited_deletedAt", ["deletedAt"])

--- a/packages/indexer-database/src/migrations/1742921797170-Deposits.ts
+++ b/packages/indexer-database/src/migrations/1742921797170-Deposits.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Deposits1742921797170 implements MigrationInterface {
+  name = "Deposits1742921797170";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."v3_funds_deposited" DROP CONSTRAINT "UK_v3FundsDeposited_relayHash_block_logIdx"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."v3_funds_deposited" ADD CONSTRAINT "UK_FundsDeposited_relayHash_block_txnHash_logIdx" UNIQUE ("relayHash", "blockNumber", "transactionHash", "logIndex")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."v3_funds_deposited" DROP CONSTRAINT "UK_FundsDeposited_relayHash_block_txnHash_logIdx"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."v3_funds_deposited" ADD CONSTRAINT "UK_v3FundsDeposited_relayHash_block_logIdx" UNIQUE ("relayHash", "logIndex", "blockNumber")`,
+    );
+  }
+}

--- a/packages/indexer/src/database/SpokePoolRepository.ts
+++ b/packages/indexer/src/database/SpokePoolRepository.ts
@@ -70,7 +70,7 @@ export class SpokePoolRepository extends dbUtils.BlockchainEventRepository {
         this.saveAndHandleFinalisationBatch<entities.V3FundsDeposited>(
           entities.V3FundsDeposited,
           eventsChunk,
-          ["relayHash", "blockNumber", "logIndex"],
+          ["relayHash", "blockNumber", "transactionHash", "logIndex"],
           [],
         ),
       ),


### PR DESCRIPTION
To handle Solana reorgs, we’ve added `transactionHash` to the unique constraint of the deposits table, now defined as (relayHash, blockNumber, transactionHash, logIndex).

Unlike EVM chains, Solana lacks a global log index per block, so we can’t rely on logIndex alone to uniquely identify transactions. Including transactionHash ensures uniqueness, as it’s generated from transaction data and remains consistent during reorgs, even if the blockNumber (or slot) changes.