### PR TITLE
fix: cap end block for bundle reconstruction

### DIFF
--- a/packages/indexer/src/services/BundleServicesManager.ts
+++ b/packages/indexer/src/services/BundleServicesManager.ts
@@ -55,6 +55,7 @@ export class BundleServicesManager {
       hubPoolClientFactory: this.hubPoolClientFactory,
       spokePoolClientFactory: this.spokePoolClientFactory,
       bundleRepository: this.bundleRepository,
+      retryProvidersFactory: this.retryProvidersFactory,
     });
     return this.bundleIncludedEventsService.start(10);
   }


### PR DESCRIPTION
We add a buffer to the bundle range blocks when reconstructing it. Sometimes, after adding the buffer, we try to query a block which is greater than the latest block. This PR fixes that.