### PR TITLE
improve(api): add sorting by block time

### DIFF
--- a/packages/indexer-api/src/services/deposits.ts
+++ b/packages/indexer-api/src/services/deposits.ts
@@ -38,7 +38,7 @@ export class DepositsService {
         `rhi.fillTxHash as "fillTxHash"`,
         `rhi.depositRefundTxHash as "depositRefundTxHash"`,
       ])
-      .orderBy("deposit.quoteTimestamp", "DESC");
+      .orderBy("deposit.blockTimestamp", "DESC");
 
     if (params.depositor) {
       queryBuilder.andWhere("deposit.depositor = :depositor", {
@@ -227,7 +227,7 @@ export class DepositsService {
         `rhi.status as status`,
         `rhi.depositRefundTxHash as "depositRefundTxHash"`,
       ])
-      .orderBy("deposit.quoteTimestamp", "DESC");
+      .orderBy("deposit.blockTimestamp", "DESC");
 
     if (originChainId) {
       queryBuilder.andWhere("deposit.originChainId = :originChainId", {
@@ -278,16 +278,17 @@ export class DepositsService {
         "fill.id = rhi.fillEventId",
       )
       .where("rhi.status = :status", { status: entities.RelayStatus.Filled })
+      .andWhere("deposit.blockTimestamp BETWEEN :startDate AND :endDate", {
+        startDate,
+        endDate,
+      })
       .select([
         "deposit.*", // Select all columns from depositEvent
         "rhi.status as status", // Select status from RelayHashInfo
         "fill.relayer as relayer", // Select relayer from FillEvent
         "fill.blockTimestamp as fillBlockTimestamp", // Select blockTimestamp from fillEvent
       ])
-      .andWhere("deposit.blockTimestamp BETWEEN :startDate AND :endDate", {
-        startDate,
-        endDate,
-      });
+      .orderBy("deposit.blockTimestamp", "DESC");
 
     if (originChainId) {
       queryBuilder.andWhere("deposit.originChainId = :originChainId", {

--- a/packages/indexer-api/src/services/fills.ts
+++ b/packages/indexer-api/src/services/fills.ts
@@ -36,7 +36,8 @@ export class FillsService {
         startDate,
         endDate,
       })
-      .select(["fill.*", `rhi.status as status`]);
+      .select(["fill.*", `rhi.status as status`])
+      .orderBy("fill.blockTimestamp", "DESC");
 
     if (originChainId) {
       queryBuilder.andWhere("fill.originChainId = :originChainId", {


### PR DESCRIPTION
# motivation
we are seeing queries where deposits returned get skipped for some reason

# changes
This does a sort before any major filtering to make sure its return in block time order, to make results easier to reason about