### PR TITLE
chore: remove headers from provider set up

### DIFF
--- a/packages/indexer/src/parseEnv.ts
+++ b/packages/indexer/src/parseEnv.ts
@@ -124,20 +124,6 @@ export function parseProvidersUrls() {
   return results;
 }
 
-export function parseProviderHeaders(chainId: number) {
-  // Permit env-based HTTP headers to be specified.
-  // RPC_PROVIDER_<chainId>_HEADERS=auth
-  // RPC_PROVIDER_<chainId>_HEADER_AUTH=xxx-auth-header
-  let headers: { [k: string]: string } = {};
-  const _headers = process.env[`RPC_PROVIDER_HEADERS_${chainId}`];
-  _headers?.split(",").forEach((header) => {
-    headers[header] =
-      process.env[`RPC_PROVIDER_HEADER_${header.toUpperCase()}_${chainId}`]!;
-  });
-
-  return headers;
-}
-
 export function parseRetryProviderEnvs(chainId: number): RetryProviderConfig {
   const providerCacheNamespace =
     process.env.PROVIDER_CACHE_NAMESPACE || "indexer_provider_cache";


### PR DESCRIPTION
We needed headers to use Matter Labs as a Lens provider, but Alchemy is now live so we don't need that anymore.
Zion PR removing envs: https://github.com/UMAprotocol/zion/pull/653