### PR TITLE
fix: improve deposits query

### DIFF
--- a/packages/indexer-api/src/services/deposits.ts
+++ b/packages/indexer-api/src/services/deposits.ts
@@ -75,7 +75,7 @@ export class DepositsService {
     const repo = this.db.getRepository(entities.V3FundsDeposited);
     const queryBuilder = repo
       .createQueryBuilder("deposit")
-      .leftJoinAndSelect(
+      .innerJoinAndSelect(
         entities.RelayHashInfo,
         "rhi",
         "rhi.depositEventId = deposit.id",


### PR DESCRIPTION
in order to fetch only deposits that were matched with a relay hash info, we need to make an inner join