### PR TITLE
improve: rename return fields to match deposit status

### DIFF
--- a/packages/indexer-api/src/dtos/deposits.dto.ts
+++ b/packages/indexer-api/src/dtos/deposits.dto.ts
@@ -80,7 +80,7 @@ export type DepositReturnType = {
   fillDeadline: Date;
   quoteTimestamp: Date;
 
-  depositTransactionHash: string;
+  depositTxHash: string; // Renamed from depositTransactionHash
   depositBlockNumber: number;
   depositBlockTimestamp?: Date;
 
@@ -99,7 +99,7 @@ export type DepositReturnType = {
   // from fill
   relayer?: string;
   fillBlockTimestamp?: Date;
-  fillTransactionHash?: string;
+  fillTx?: string; // Renamed from fillTransactionHash
 
   // from swap
   swapTransactionHash?: string;
@@ -113,4 +113,22 @@ export type DepositReturnType = {
     updatedMessage: string;
     blockNumber: number;
   }[];
+};
+
+// Define a type for the pagination information
+export type PaginationInfo = {
+  currentIndex: number;
+  maxIndex: number;
+};
+
+// Define a type for the deposit status response
+export type DepositStatusResponse = {
+  status: string | entities.RelayStatus;
+  originChainId: number;
+  depositId: string;
+  depositTxHash: string | null;
+  fillTx: string | undefined;
+  destinationChainId: number;
+  depositRefundTxHash: string | undefined;
+  pagination: PaginationInfo;
 };

--- a/packages/indexer-api/src/services/deposits.ts
+++ b/packages/indexer-api/src/services/deposits.ts
@@ -5,6 +5,8 @@ import type {
   DepositsParams,
   FilterDepositsParams,
   DepositReturnType,
+  PaginationInfo,
+  DepositStatusResponse,
 } from "../dtos/deposits.dto";
 import {
   DepositNotFoundException,
@@ -34,7 +36,7 @@ const DepositFields = [
   `deposit.exclusivityDeadline as "exclusivityDeadline"`,
   `deposit.fillDeadline as "fillDeadline"`,
   `deposit.quoteTimestamp as "quoteTimestamp"`,
-  `deposit.transactionHash as "depositTransactionHash"`,
+  `deposit.transactionHash as "depositTxHash"`, // Renamed field
   `deposit.blockNumber as "depositBlockNumber"`,
   `deposit.blockTimestamp as "depositBlockTimestamp"`,
 ];
@@ -55,7 +57,7 @@ const RelayHashInfoFields = [
 const FilledRelayFields = [
   `fill.relayer as "relayer"`,
   `fill.blockTimestamp as "fillBlockTimestamp"`,
-  `fill.transactionHash as "fillTransactionHash"`,
+  `fill.transactionHash as "fillTx"`, // Renamed field
 ];
 
 const SwapBeforeBridgeFields = [
@@ -191,7 +193,9 @@ export class DepositsService {
     );
   }
 
-  public async getDepositStatus(params: DepositParams) {
+  public async getDepositStatus(
+    params: DepositParams,
+  ): Promise<DepositStatusResponse> {
     // in the validation rules each of these params are marked as optional
     // but we need to check that at least one of them is present
     if (


### PR DESCRIPTION
# motivation
we want to see return types the same as the deposit status return type

# changes
Only a couple fields needed to change in the other endpoints