### PR TITLE
fix: wrap spoke pool indexer in a sql transaction

### DIFF
--- a/packages/indexer-database/src/main.ts
+++ b/packages/indexer-database/src/main.ts
@@ -7,6 +7,7 @@ import {
   In,
   LessThan,
   Not,
+  EntityManager,
 } from "typeorm";
 import * as entities from "./entities";
 import { DatabaseConfig } from "./model";
@@ -19,6 +20,7 @@ export {
   In,
   LessThan,
   Not,
+  EntityManager,
 };
 
 export const createDataSource = (config: DatabaseConfig): DataSource => {

--- a/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
+++ b/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
@@ -122,6 +122,7 @@ export class AcrossIndexerManager {
             this.webhookWriteFn,
           ),
           this.indexerQueuesService,
+          this.postgres,
         );
         const spokePoolIndexer = new EvmIndexer(
           {

--- a/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SpokePoolIndexerDataHandler.ts
@@ -6,7 +6,9 @@ import {
 } from "@across-protocol/contracts";
 import { providers } from "ethers";
 import {
+  DataSource,
   entities,
+  EntityManager,
   utils as indexerDatabaseUtils,
   SaveQueryResult,
   SaveQueryResultType,
@@ -68,6 +70,11 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
     private swapBeforeBridgeRepository: SwapBeforeBridgeRepository,
     private spokePoolProcessor: SpokePoolProcessor,
     private indexerQueuesService: IndexerQueuesService,
+    /*
+     * The postgres DataSource is used to execute low level queries such as starting a transaction.
+     * THIS IS AN EXCEPTION! Most of the queries are encouraged to be executed through the repository or entity classes.
+     */
+    private postgres: DataSource,
   ) {
     this.isInitialized = false;
   }
@@ -137,66 +144,19 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
       },
       blockRange,
     });
-    const storedEvents = await this.storeEvents(events, lastFinalisedBlock);
-    const newInsertedDeposits = indexerDatabaseUtils.filterSaveQueryResults(
-      storedEvents.deposits,
-      SaveQueryResultType.Inserted,
-    );
-    const newInsertedFills = indexerDatabaseUtils.filterSaveQueryResults(
-      storedEvents.fills,
-      SaveQueryResultType.Inserted,
-    );
-
-    // Fetch transaction receipts associated only to new inserted events:
-    // (1) deposits for getting the swap before bridge events, (2) fills for getting the gas fee
-    const transactionReceipts = await this.getTransactionReceiptsForEvents([
-      ...newInsertedDeposits,
-      ...newInsertedFills,
-    ]);
-
-    const depositSwapPairs = await this.matchDepositEventsWithSwapEvents(
-      newInsertedDeposits,
-      transactionReceipts,
-      lastFinalisedBlock,
+    // Starting from here the execution flow is wrapped in a SQL transaction to ensure atomicity.
+    // In case of an error, the database should be rolled back to the state before the block range was processed.
+    const { metrics } = await this.postgres.transaction(
+      async (transactionalEntityManager) => {
+        const result = await this.processBlockRangeEvents(
+          transactionalEntityManager,
+          events,
+          lastFinalisedBlock,
+        );
+        return result;
+      },
     );
 
-    //FIXME: Remove performance timing
-    const timeToStoreEvents = performance.now();
-
-    // Delete unfinalised events
-    const [deletedDeposits, _] = await Promise.all([
-      this.spokePoolClientRepository.deleteUnfinalisedDepositEvents(
-        this.chainId,
-        lastFinalisedBlock,
-      ),
-      this.swapBeforeBridgeRepository.deleteUnfinalisedSwapEvents(
-        this.chainId,
-        lastFinalisedBlock,
-      ),
-    ]);
-    const timeToDeleteDeposits = performance.now();
-    await this.updateNewDepositsWithIntegratorId(newInsertedDeposits);
-
-    //FIXME: Remove performance timing
-    const timeToUpdateDepositIds = performance.now();
-
-    await this.spokePoolProcessor.process(
-      storedEvents,
-      deletedDeposits,
-      depositSwapPairs,
-      transactionReceipts,
-    );
-
-    //FIXME: Remove performance timing
-    const timeToProcessDeposits = performance.now();
-
-    this.profileStoreEvents(storedEvents);
-
-    // publish new relays to workers to fill in prices
-    await this.publishNewRelays(storedEvents);
-    await this.publishSwaps(depositSwapPairs);
-
-    //FIXME: Remove performance timing
     const finalPerfTime = performance.now();
 
     this.logger.debug({
@@ -206,13 +166,92 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
       spokeChainId: this.chainId,
       blockRange: blockRange,
       timeToFetchEvents: timeToFetchEvents - startPerfTime,
-      timeToStoreEvents: timeToStoreEvents - timeToFetchEvents,
-      timeToDeleteDeposits: timeToDeleteDeposits - timeToStoreEvents,
-      timeToUpdateDepositIds: timeToUpdateDepositIds - timeToDeleteDeposits,
-      timeToProcessDeposits: timeToProcessDeposits - timeToUpdateDepositIds,
-      timeToProcessAnciliaryEvents: finalPerfTime - timeToProcessDeposits,
+      timeToStoreEvents: metrics.timeToStoreEvents - timeToFetchEvents,
+      timeToDeleteDeposits:
+        metrics.timeToDeleteDeposits - metrics.timeToStoreEvents,
+      timeToUpdateDepositIds:
+        metrics.timeToUpdateWithIntegratorId - metrics.timeToDeleteDeposits,
+      timeToProcessDeposits:
+        metrics.timeToProcessDeposits - metrics.timeToUpdateWithIntegratorId,
+      timeToProcessAnciliaryEvents:
+        finalPerfTime - metrics.timeToProcessDeposits,
       finalTime: finalPerfTime - startPerfTime,
     });
+  }
+
+  private async processBlockRangeEvents(
+    transactionalEntityManager: EntityManager,
+    events: FetchEventsResult,
+    lastFinalisedBlock: number,
+  ) {
+    const storedEvents = await this.storeEvents(
+      transactionalEntityManager,
+      events,
+      lastFinalisedBlock,
+    );
+    const newInsertedDeposits = indexerDatabaseUtils.filterSaveQueryResults(
+      storedEvents.deposits,
+      SaveQueryResultType.Inserted,
+    );
+    const newInsertedFills = indexerDatabaseUtils.filterSaveQueryResults(
+      storedEvents.fills,
+      SaveQueryResultType.Inserted,
+    );
+    const transactionReceipts = await this.getTransactionReceiptsForEvents([
+      ...newInsertedDeposits,
+      ...newInsertedFills,
+    ]);
+    const depositSwapPairs = await this.matchDepositEventsWithSwapEvents(
+      newInsertedDeposits,
+      transactionReceipts,
+      lastFinalisedBlock,
+      transactionalEntityManager,
+    );
+    const timeToStoreEvents = performance.now();
+    // Delete unfinalised events because we are past the lastFinalisedBlock and unfinalised events means a reorg happened
+    const [deletedDeposits, _] = await Promise.all([
+      this.spokePoolClientRepository.deleteUnfinalisedDepositEvents(
+        this.chainId,
+        lastFinalisedBlock,
+        transactionalEntityManager,
+      ),
+      this.swapBeforeBridgeRepository.deleteUnfinalisedSwapEvents(
+        this.chainId,
+        lastFinalisedBlock,
+        transactionalEntityManager,
+      ),
+    ]);
+    const timeToDeleteDeposits = performance.now();
+
+    await this.updateNewDepositsWithIntegratorId(
+      newInsertedDeposits,
+      transactionalEntityManager,
+    );
+    const timeToUpdateWithIntegratorId = performance.now();
+
+    await this.spokePoolProcessor.process(
+      storedEvents,
+      deletedDeposits,
+      depositSwapPairs,
+      transactionReceipts,
+      transactionalEntityManager,
+    );
+    const timeToProcessDeposits = performance.now();
+
+    this.profileStoreEvents(storedEvents);
+
+    // publish new relays to workers to fill in prices
+    await this.publishNewRelays(storedEvents);
+    await this.publishSwaps(depositSwapPairs);
+
+    return {
+      metrics: {
+        timeToStoreEvents,
+        timeToDeleteDeposits,
+        timeToUpdateWithIntegratorId,
+        timeToProcessDeposits,
+      },
+    };
   }
 
   /**
@@ -226,6 +265,7 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
     deposits: entities.V3FundsDeposited[],
     transactionReceipts: Record<string, providers.TransactionReceipt>,
     lastFinalisedBlock: number,
+    transactionalEntityManager: EntityManager,
   ) {
     const transactionReceiptsList = Object.values(transactionReceipts);
     const swapBeforeBridgeEvents = transactionReceiptsList
@@ -242,6 +282,7 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
         swapBeforeBridgeEvents,
         this.chainId,
         lastFinalisedBlock,
+        transactionalEntityManager,
       );
     const insertedSwapBeforeBridgeEvents =
       indexerDatabaseUtils.filterSaveQueryResults(
@@ -521,6 +562,7 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
   }
 
   private async storeEvents(
+    transactionalEntityManager: EntityManager,
     params: FetchEventsResult,
     lastFinalisedBlock: number,
   ): Promise<StoreEventsResult> {
@@ -545,32 +587,39 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
         v3FundsDepositedEvents,
         lastFinalisedBlock,
         blockTimes,
+        transactionalEntityManager,
       ),
       spokePoolClientRepository.formatAndSaveRequestedV3SlowFillEvents(
         requestedV3SlowFillEvents,
         lastFinalisedBlock,
+        transactionalEntityManager,
       ),
       spokePoolClientRepository.formatAndSaveFilledV3RelayEvents(
         filledV3RelayEvents,
         lastFinalisedBlock,
         blockTimes,
+        transactionalEntityManager,
       ),
       spokePoolClientRepository.formatAndSaveExecutedRelayerRefundRootEvents(
         executedRelayerRefundRootEvents,
         lastFinalisedBlock,
+        transactionalEntityManager,
       ),
       spokePoolClientRepository.formatAndSaveRequestedSpeedUpV3Events(
         requestedSpeedUpV3Events,
         lastFinalisedBlock,
+        transactionalEntityManager,
       ),
       spokePoolClientRepository.formatAndSaveRelayedRootBundleEvents(
         relayedRootBundleEvents,
         this.chainId,
         lastFinalisedBlock,
+        transactionalEntityManager,
       ),
       spokePoolClientRepository.formatAndSaveTokensBridgedEvents(
         tokensBridgedEvents,
         lastFinalisedBlock,
+        transactionalEntityManager,
       ),
     ]);
     return {
@@ -583,6 +632,7 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
 
   private async updateNewDepositsWithIntegratorId(
     deposits: entities.V3FundsDeposited[],
+    transactionalEntityManager: EntityManager,
   ) {
     await across.utils.forEachAsync(deposits, async (deposit) => {
       const integratorId = await utils.getIntegratorId(
@@ -594,6 +644,7 @@ export class SpokePoolIndexerDataHandler implements IndexerDataHandler {
         await this.spokePoolClientRepository.updateDepositEventWithIntegratorId(
           deposit.id,
           integratorId,
+          transactionalEntityManager,
         );
       }
     });

--- a/packages/indexer/src/database/SwapBeforeBridgeRepository.ts
+++ b/packages/indexer/src/database/SwapBeforeBridgeRepository.ts
@@ -1,6 +1,11 @@
 import winston from "winston";
 import * as across from "@across-protocol/sdk";
-import { DataSource, entities, utils as dbUtils } from "@repo/indexer-database";
+import {
+  DataSource,
+  entities,
+  utils as dbUtils,
+  EntityManager,
+} from "@repo/indexer-database";
 import { SwapBeforeBridgeEvent } from "../web3/model/events";
 
 export class SwapBeforeBridgeRepository extends dbUtils.BlockchainEventRepository {
@@ -16,6 +21,7 @@ export class SwapBeforeBridgeRepository extends dbUtils.BlockchainEventRepositor
     swapBeforeBridgeEvents: SwapBeforeBridgeEvent[],
     chainId: number,
     lastFinalisedBlock: number,
+    transactionalEntityManager?: EntityManager,
   ) {
     const formattedEvents = swapBeforeBridgeEvents.map((event) => {
       const entity = new entities.SwapBeforeBridge();
@@ -42,6 +48,7 @@ export class SwapBeforeBridgeRepository extends dbUtils.BlockchainEventRepositor
           eventsChunk,
           ["blockNumber", "chainId", "logIndex"],
           [],
+          transactionalEntityManager,
         ),
       ),
     );
@@ -52,6 +59,7 @@ export class SwapBeforeBridgeRepository extends dbUtils.BlockchainEventRepositor
   public async deleteUnfinalisedSwapEvents(
     chainId: number,
     lastFinalisedBlock: number,
+    transactionalEntityManager?: EntityManager,
   ) {
     const chainIdColumn = "chainId";
     const deletedSwapEvents = await this.deleteUnfinalisedEvents(
@@ -59,6 +67,7 @@ export class SwapBeforeBridgeRepository extends dbUtils.BlockchainEventRepositor
       chainIdColumn,
       lastFinalisedBlock,
       entities.SwapBeforeBridge,
+      transactionalEntityManager,
     );
     return deletedSwapEvents;
   }


### PR DESCRIPTION
This PR wraps the execution of `SpokePoolIndexerDataHandler.processBlockRange()` in a SQL transaction. In case of throwing an error, the database should be reverted to the state prior to the block range being processed.

- `fetchEventsByRange` is not included in the SQL transaction
- all queries must be executed using the new `transactionalEntityManager`
- to ensure backwards compatibility, in some functions `transactionalEntityManager` is marked as optional. In such cases the queries are executed using the `DataSource` instance
**Example:**
```javascript
const repository = transactionalEntityManager
      ? transactionalEntityManager.getRepository(entity)
      : this.postgres.getRepository(entity);
```
- managed advisory locks `pg_advisory_xact_lock` that gets released automatically after the transaction ends get replaced with session lived `pg_advisory_lock` which needs to be unlocked `explicitly`
The following pattern has been using in the `SpokePoolProcessor`:
```javascript
try {
     // Acquire a lock to prevent concurrent modifications on the same relayHash
     call pg_advisory_lock(),
} finally {
    // Explicitly call unlock for both successful or failed execution
     call pg_advisory_unlock()
}
```