### PR TITLE
fix: update relay hash info with unmatched fills

### DIFF
--- a/packages/indexer-database/src/entities/evm/FilledV3Relay.ts
+++ b/packages/indexer-database/src/entities/evm/FilledV3Relay.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   PrimaryGeneratedColumn,
   Unique,
 } from "typeorm";
@@ -9,6 +10,7 @@ import { interfaces } from "@across-protocol/sdk";
 
 @Entity({ schema: "evm" })
 @Unique("UK_filledV3Relay_internalHash", ["internalHash"])
+@Index("IX_filledV3Relay_blockTimestamp", ["blockTimestamp"])
 export class FilledV3Relay {
   @PrimaryGeneratedColumn()
   id: number;

--- a/packages/indexer-database/src/migrations/1746458849679-FilledV3Relay.ts
+++ b/packages/indexer-database/src/migrations/1746458849679-FilledV3Relay.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FilledV3Relay1746458849679 implements MigrationInterface {
+  name = "FilledV3Relay1746458849679";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IX_filledV3Relay_blockTimestamp" ON "evm"."filled_v3_relay" ("blockTimestamp") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "evm"."IX_filledV3Relay_blockTimestamp"`,
+    );
+  }
+}

--- a/packages/indexer/src/parseEnv.ts
+++ b/packages/indexer/src/parseEnv.ts
@@ -17,6 +17,7 @@ export type Config = {
   svmSpokePoolChainsEnabled: number[];
   enableHubPoolIndexer: boolean;
   enableBundleIncludedEventsService: boolean;
+  enableHotfixServices: boolean;
   enableBundleBuilder: boolean;
   webhookConfig: WebhooksConfig;
   maxBlockRangeSize?: number;
@@ -199,6 +200,9 @@ export function envToConfig(env: Env): Config {
     env.ENABLE_BUNDLE_INCLUDED_EVENTS_SERVICE
       ? env.ENABLE_BUNDLE_INCLUDED_EVENTS_SERVICE === "true"
       : true;
+  const enableHotfixServices = env.ENABLE_HOTFIX_SERVICES
+    ? env.ENABLE_HOTFIX_SERVICES === "true"
+    : false;
   const enableBundleBuilder = env.ENABLE_BUNDLE_BUILDER
     ? env.ENABLE_BUNDLE_BUILDER === "true"
     : true;
@@ -237,6 +241,7 @@ export function envToConfig(env: Env): Config {
     svmSpokePoolChainsEnabled,
     enableHubPoolIndexer,
     enableBundleIncludedEventsService,
+    enableHotfixServices,
     enableBundleBuilder,
     webhookConfig,
     maxBlockRangeSize,

--- a/packages/indexer/src/services/HotfixServicesManager.ts
+++ b/packages/indexer/src/services/HotfixServicesManager.ts
@@ -1,0 +1,44 @@
+import { Logger } from "winston";
+
+import { DataSource } from "@repo/indexer-database";
+
+import { Config } from "../parseEnv";
+import { UnmatchedFillEventsService } from "./UnmatchedFillEventsService";
+import { RetryProvidersFactory } from "../web3/RetryProvidersFactory";
+import { IndexerQueuesService } from "../messaging/service";
+
+export class HotfixServicesManager {
+  private unmatchedFillEventsService?: UnmatchedFillEventsService;
+
+  public constructor(
+    private logger: Logger,
+    private postgres: DataSource,
+    private config: Config,
+    private providersFactory: RetryProvidersFactory,
+    private indexerQueuesService: IndexerQueuesService,
+  ) {}
+  public start() {
+    return Promise.all([this.startUnmatchedFillEventsService()]);
+  }
+
+  public stop() {
+    this.unmatchedFillEventsService?.stop();
+  }
+
+  private startUnmatchedFillEventsService() {
+    if (!this.config.enableHotfixServices) {
+      this.logger.warn({
+        at: "HotfixServicesManager#startUnmatchedFillEventsService",
+        message: "UnmatchedFillEventsService is disabled",
+      });
+      return;
+    }
+    this.unmatchedFillEventsService = new UnmatchedFillEventsService(
+      this.postgres,
+      this.providersFactory,
+      this.indexerQueuesService,
+      this.logger,
+    );
+    return this.unmatchedFillEventsService.start(60);
+  }
+}

--- a/packages/indexer/src/services/UnmatchedFillEventsService.ts
+++ b/packages/indexer/src/services/UnmatchedFillEventsService.ts
@@ -1,0 +1,85 @@
+import winston from "winston";
+
+import { RepeatableTask } from "../generics";
+import { DataSource, entities } from "@repo/indexer-database";
+import { providers } from "@across-protocol/sdk";
+
+import { SpokePoolProcessor } from "./spokePoolProcessor";
+import { RetryProvidersFactory } from "../web3/RetryProvidersFactory";
+import { IndexerQueues } from "../messaging/service";
+import { IndexerQueuesService } from "../messaging/service";
+import { PriceMessage } from "../messaging/priceWorker";
+
+export class UnmatchedFillEventsService extends RepeatableTask {
+  constructor(
+    private readonly postgres: DataSource,
+    private readonly providersFactory: RetryProvidersFactory,
+    private readonly indexerQueuesService: IndexerQueuesService,
+    logger: winston.Logger,
+  ) {
+    super(logger, UnmatchedFillEventsService.name);
+  }
+
+  protected async taskLogic() {
+    const now = new Date();
+    const qb = this.postgres.createQueryBuilder(entities.RelayHashInfo, "rhi");
+
+    qb.leftJoinAndMapOne(
+      "rhi.fillEvent",
+      entities.FilledV3Relay,
+      "f",
+      "f.internalHash = rhi.internalHash",
+    )
+      .where("rhi.status = :status", { status: "expired" })
+      .andWhere("f.id is not null")
+      .andWhere("f.blockTimestamp >= '2025-02-01'")
+      .andWhere("now() - f.blockTimestamp > interval '5 minutes'")
+      .orderBy("f.blockTimestamp", "DESC")
+      .limit(100);
+    const results = await qb.getMany();
+    this.logger.debug({
+      at: "UnmatchedFillEventsService#taskLogic",
+      message: `Found ${results.length} unmatched fill events`,
+    });
+
+    for (const rhi of results) {
+      if (!rhi.fillEvent) {
+        throw new Error(`Fill event not found for relay hash info ${rhi.id}`);
+      }
+      const spokePoolProcessor = new SpokePoolProcessor(
+        this.postgres,
+        rhi.destinationChainId,
+        this.logger,
+      );
+      const transactionReceipt = await (
+        this.providersFactory.getProviderForChainId(
+          rhi.destinationChainId,
+        ) as providers.RetryProvider
+      ).getTransactionReceipt(rhi.fillEvent.transactionHash);
+      await spokePoolProcessor.assignSpokeEventsToRelayHashInfo({
+        deposits: [],
+        fills: [rhi.fillEvent],
+        slowFillRequests: [],
+        transactionReceipts: {
+          [rhi.fillEvent.transactionHash]: transactionReceipt,
+        },
+      });
+      const messages: PriceMessage[] = [{ fillEventId: rhi.fillEvent.id }];
+      await this.indexerQueuesService.publishMessagesBulk(
+        IndexerQueues.PriceQuery,
+        IndexerQueues.PriceQuery,
+        messages,
+      );
+    }
+
+    const totalTime = new Date().getTime() - now.getTime();
+    this.logger.debug({
+      at: "UnmatchedFillEventsService#taskLogic",
+      message: `Total time: ${totalTime / 1000}s`,
+    });
+  }
+
+  protected initialize() {
+    return Promise.resolve();
+  }
+}


### PR DESCRIPTION
This PR looks for expired `relay_hash_info` records with expired status, but for which fill events exists in the raw events table