### PR TITLE
feat: use SVM spoke pool client to query events

### DIFF
--- a/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
+++ b/packages/indexer/src/data-indexing/service/AcrossIndexerManager.ts
@@ -165,6 +165,8 @@ export class AcrossIndexerManager {
             this.retryProvidersFactory.getProviderForChainId(
               chainId,
             ) as SvmProvider,
+            this.configStoreClientFactory,
+            this.hubPoolClientFactory,
           );
         const svmIndexer = new SvmIndexer(
           {

--- a/packages/indexer/src/data-indexing/service/SvmSpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SvmSpokePoolIndexerDataHandler.ts
@@ -169,7 +169,7 @@ export class SvmSpokePoolIndexerDataHandler implements IndexerDataHandler {
     const endTimeToGetSlotTimes = performance.now();
 
     this.logger.debug({
-      at: "SpokePoolIndexerDataHandler#fetchEventsByRange",
+      at: "SvmSpokePoolIndexerDataHandler#fetchEventsByRange",
       message: "Time to update protocol clients",
       timeToUpdateProtocolClients: timeToUpdateProtocolClients - initialTime,
       timeToUpdateSpokePoolClient:

--- a/packages/indexer/src/data-indexing/service/SvmSpokePoolIndexerDataHandler.ts
+++ b/packages/indexer/src/data-indexing/service/SvmSpokePoolIndexerDataHandler.ts
@@ -3,9 +3,7 @@ import * as across from "@across-protocol/sdk";
 import {
   getDeployedAddress,
   getDeployedBlockNumber,
-  SvmSpokeClient,
 } from "@across-protocol/contracts";
-import { Signature, Address, UnixTimestamp } from "@solana/kit";
 
 import * as utils from "../../utils";
 import { BlockRange } from "../model";
@@ -14,47 +12,42 @@ import { getMaxBlockLookBack } from "../../web3/constants";
 import { SvmProvider } from "../../web3/RetryProvidersFactory";
 
 export type FetchEventsResult = {
-  depositEvents: any; // TODO: fix type. Needs SDK changes
-  fillEvents: any; // TODO: fix type. Needs SDK changes
-};
-
-// TODO: Export this type from the SDK and use it from there.
-export type EventData =
-  | SvmSpokeClient.FilledRelay
-  | SvmSpokeClient.FundsDeposited;
-
-// TODO: Export this type from the SDK and use it from there.
-export enum SVMEventNames {
-  FilledRelay = "FilledRelay",
-  FundsDeposited = "FundsDeposited",
-}
-
-// TODO: Export this type from the SDK and use it from there.
-export type EventName = keyof typeof SVMEventNames;
-
-// TODO: Export this type from the SDK and use it from there.
-export type EventWithData<T extends EventData> = {
-  confirmationStatus: string | null;
-  blockTime: UnixTimestamp | null;
-  signature: Signature;
-  slot: bigint;
-  name: EventName;
-  data: T;
-  program: Address;
-};
-
-// Teach BigInt how to be represented as JSON.
-(BigInt.prototype as any).toJSON = function () {
-  return this.toString();
+  fundsDepositedEvents: utils.V3FundsDepositedWithIntegradorId[];
+  filledRelayEvents: across.interfaces.FillWithBlock[];
+  requestedSlowFillEvents: across.interfaces.SlowFillRequestWithBlock[];
+  relayedRootBundleEvents: across.interfaces.RootBundleRelayWithBlock[];
+  executedRelayerRefundRootEvents: (across.interfaces.RelayerRefundExecutionWithBlock & {
+    deferredRefunds: boolean;
+  })[]; // TODO: Add missing property to SDK type
+  tokensBridgedEvents: across.interfaces.TokensBridged[];
+  slotTimes: Record<number, number>;
 };
 
 export class SvmSpokePoolIndexerDataHandler implements IndexerDataHandler {
+  private configStoreClient: across.clients.AcrossConfigStoreClient;
+  private hubPoolClient: across.clients.HubPoolClient;
+  private isInitialized: boolean;
+
   constructor(
     private logger: Logger,
     private chainId: number,
     private hubPoolChainId: number,
     private provider: SvmProvider,
+    private configStoreFactory: utils.ConfigStoreClientFactory,
+    private hubPoolFactory: utils.HubPoolClientFactory,
   ) {}
+
+  private initialize() {
+    this.configStoreClient = this.configStoreFactory.get(this.hubPoolChainId);
+    this.hubPoolClient = this.hubPoolFactory.get(
+      this.hubPoolChainId,
+      undefined,
+      undefined,
+      {
+        configStoreClient: this.configStoreClient,
+      },
+    );
+  }
 
   public getDataIdentifier() {
     return `${getDeployedAddress("SvmSpoke", this.chainId)}:${this.chainId}`;
@@ -77,23 +70,32 @@ export class SvmSpokePoolIndexerDataHandler implements IndexerDataHandler {
       isBackfilling,
     });
 
+    if (!this.isInitialized) {
+      this.initialize();
+      this.isInitialized = true;
+    }
+
     const events = await this.fetchEventsByRange(blockRange, isBackfilling);
 
-    await this.updateNewDepositsWithIntegratorId(events.depositEvents);
-
     this.logger.debug({
-      at: "Indexer#SpokePoolIndexerDataHandler#processBlockRange",
+      at: "Indexer#SvmSpokePoolIndexerDataHandler#processBlockRange",
       message: `Found events for ${this.getDataIdentifier()}`,
       events: {
-        depositEvents: events.depositEvents.length,
-        fillEvents: events.fillEvents.length,
+        fundsDepositedEvents: events.fundsDepositedEvents.length,
+        filledRelayEvents: events.filledRelayEvents.length,
+        requestedSlowFillEvents: events.requestedSlowFillEvents.length,
+        relayedRootBundleEvents: events.relayedRootBundleEvents.length,
+        executedRelayerRefundRootEvents:
+          events.executedRelayerRefundRootEvents.length,
+        tokensBridgedEvents: events.tokensBridgedEvents.length,
       },
       blockRange,
     });
 
+    await this.updateNewDepositsWithIntegratorId(events.fundsDepositedEvents);
+
     // TODO:
     // - store events
-    // - get block times
     // - delete unfinalised events
     // - process events
     // - publish price messages
@@ -103,7 +105,6 @@ export class SvmSpokePoolIndexerDataHandler implements IndexerDataHandler {
     blockRange: BlockRange,
     isBackfilling: boolean,
   ): Promise<FetchEventsResult> {
-    // NOTE: maxBlockLookback is not a supported config in the svm client. Add when supported.
     // If we are in a backfilling state then we should grab the largest
     // lookback available to us. Otherwise, for this specific indexer we
     // only need exactly what we're looking for, plus some padding to be sure
@@ -114,56 +115,112 @@ export class SvmSpokePoolIndexerDataHandler implements IndexerDataHandler {
           (blockRange.to - blockRange.from) * 2,
         );
 
-    const spokePoolClient = await across.arch.svm.SvmCpiEventsClient.create(
+    // TODO: create svm spoke pool client factory and instantiate client using it as we do for evm
+    const spokePoolClient = await across.clients.SvmSpokePoolClient.create(
+      this.logger,
+      this.hubPoolClient,
+      this.chainId,
+      BigInt(this.getStartIndexingBlockNumber()),
+      { from: blockRange.from, to: blockRange.to },
       this.provider,
     );
-    // NOTE: svm spoke client uses bigint
-    const fromSlot = BigInt(blockRange.from);
-    const toSlot = BigInt(blockRange.to);
 
-    const depositEvents = await spokePoolClient.queryEvents(
-      "FundsDeposited",
-      fromSlot,
-      toSlot,
-    );
-    const fillEvents = await spokePoolClient.queryEvents(
+    const initialTime = performance.now();
+
+    await this.configStoreClient.update();
+    await this.hubPoolClient.update([
+      "SetPoolRebalanceRoute",
+      "CrossChainContractsSet",
+    ]);
+
+    const timeToUpdateProtocolClients = performance.now();
+    // We aim to avoid the unneeded update events
+    // Specifically, we avoid the EnabledDepositRoute event because this
+    // requires a lookback to the deployment block of the SpokePool contract.
+    await spokePoolClient.update([
+      "ExecutedRelayerRefundRoot",
       "FilledRelay",
-      fromSlot,
-      toSlot,
-    );
+      "FundsDeposited",
+      "RelayedRootBundle",
+      "RequestedSlowFill",
+      "TokensBridged",
+    ]);
 
-    // NOTE: we can log events for now as it should be a short list
-    if (depositEvents.length > 0) {
-      this.logger.debug({
-        at: "Indexer#SvmSpokePoolIndexerDataHandler#processBlockRange",
-        message: `Found deposit events for ${this.getDataIdentifier()}`,
-        depositEvents,
-        blockRange,
-      });
-    }
+    const timeToUpdateSpokePoolClient = performance.now();
+    const fundsDepositedEvents = spokePoolClient.getDeposits({
+      fromBlock: blockRange.from,
+      toBlock: blockRange.to,
+    });
+    const filledRelayEvents = spokePoolClient.getFills();
+    const requestedSlowFillEvents = spokePoolClient.getSlowFillRequests();
+    const relayedRootBundleEvents = spokePoolClient.getRootBundleRelays();
+    const executedRelayerRefundRootEvents =
+      spokePoolClient.getRelayerRefundExecutions() as FetchEventsResult["executedRelayerRefundRootEvents"];
+    const tokensBridgedEvents =
+      spokePoolClient.getTokensBridged() as FetchEventsResult["tokensBridgedEvents"];
+    // getSlotTimes function will make sure we dont query more than we need to.
+    const slots = [
+      ...fundsDepositedEvents.map((deposit) => deposit.blockNumber),
+      ...filledRelayEvents.map((fill) => fill.blockNumber),
+    ];
 
-    if (fillEvents.length > 0) {
-      this.logger.debug({
-        at: "Indexer#SvmSpokePoolIndexerDataHandler#processBlockRange",
-        message: `Found fill events for ${this.getDataIdentifier()}`,
-        fillEvents,
-        blockRange,
-      });
-    }
+    const startTimeToGetSlotTimes = performance.now();
+    const slotTimes = await this.getSlotTimes(slots);
+    const endTimeToGetSlotTimes = performance.now();
+
+    this.logger.debug({
+      at: "SpokePoolIndexerDataHandler#fetchEventsByRange",
+      message: "Time to update protocol clients",
+      timeToUpdateProtocolClients: timeToUpdateProtocolClients - initialTime,
+      timeToUpdateSpokePoolClient:
+        timeToUpdateSpokePoolClient - timeToUpdateProtocolClients,
+      timeToGetBlockTimes: endTimeToGetSlotTimes - startTimeToGetSlotTimes, // Keep log structure by using key 'timeToGetBlockTimes'
+      totalTime: endTimeToGetSlotTimes - initialTime,
+      spokeChainId: this.chainId,
+      blockRange: blockRange,
+      isBackfilling,
+      dynamicMaxBlockLookback: maxBlockLookback,
+    });
 
     return {
-      depositEvents,
-      fillEvents,
+      fundsDepositedEvents,
+      filledRelayEvents,
+      requestedSlowFillEvents,
+      relayedRootBundleEvents,
+      executedRelayerRefundRootEvents,
+      tokensBridgedEvents,
+      slotTimes,
     };
   }
 
+  private async getSlotTimes(slots: number[]): Promise<Record<number, number>> {
+    const uniqueSlots = [...new Set(slots)];
+    const timestamps = await Promise.all(
+      uniqueSlots.map((slot) =>
+        this.provider.getBlockTime(BigInt(slot)).send(),
+      ),
+    );
+
+    const slotTimestamps = uniqueSlots.reduce(
+      (acc, slot, index) => {
+        if (timestamps[index] === undefined) {
+          throw new Error(`Slot time for slot ${slot} not found`);
+        }
+        acc[slot] = Number(timestamps[index]!);
+        return acc;
+      },
+      {} as Record<number, number>,
+    );
+    return slotTimestamps;
+  }
+
   private async updateNewDepositsWithIntegratorId(
-    deposits: EventWithData<SvmSpokeClient.FundsDeposited>[],
+    deposits: FetchEventsResult["fundsDepositedEvents"],
   ) {
     await across.utils.forEachAsync(deposits, async (deposit) => {
       const integratorId = await utils.getSvmIntegratorId(
         this.provider,
-        deposit.signature,
+        deposit.txnRef,
       );
       if (integratorId) {
         // TODO: update deposit with integrator id when we are storing them in the database

--- a/packages/indexer/src/web3/RetryProvidersFactory.ts
+++ b/packages/indexer/src/web3/RetryProvidersFactory.ts
@@ -1,6 +1,6 @@
 import { Logger } from "winston";
 import { PUBLIC_NETWORKS } from "@across-protocol/constants";
-import { providers, utils } from "@across-protocol/sdk";
+import { providers, utils, arch } from "@across-protocol/sdk";
 
 import {
   parseRetryProviderEnvs,
@@ -11,10 +11,7 @@ import { RedisCache } from "../redis/redisCache";
 import { getChainCacheFollowDistance } from "./constants";
 
 // SVM provider helper type.
-// TODO: move to SDK.
-export type SvmProvider = ReturnType<
-  typeof providers.CachedSolanaRpcFactory.prototype.createRpcClient
->;
+export type SvmProvider = arch.svm.SVMProvider;
 
 export class RetryProvidersFactory {
   private retryProviders: Map<number, SvmProvider | providers.RetryProvider> =


### PR DESCRIPTION
This PR is part of the required changes to support Solana in the indexer. It replaces the SVMEventsClient with the SVMSpokePoolClient to query SVM events.

Upcoming PRs will store events in the database and process them using the SpokePoolProcessor.