### PR TITLE
chore: update hubpool events chain columns to support solana chainId

### DIFF
--- a/packages/indexer-database/src/entities/evm/RootBundleExecuted.ts
+++ b/packages/indexer-database/src/entities/evm/RootBundleExecuted.ts
@@ -23,7 +23,7 @@ export class RootBundleExecuted {
   @Column()
   groupIndex: number;
 
-  @Column()
+  @Column({ type: "bigint" })
   chainId: number;
 
   @Column({ type: "jsonb" })

--- a/packages/indexer-database/src/entities/evm/SetPoolRebalanceRoute.ts
+++ b/packages/indexer-database/src/entities/evm/SetPoolRebalanceRoute.ts
@@ -16,7 +16,7 @@ export class SetPoolRebalanceRoute {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ nullable: false })
+  @Column({ type: "bigint", nullable: false })
   destinationChainId: number;
 
   @Column({ nullable: false })

--- a/packages/indexer-database/src/migrations/1747773035048-hubPoolEventsChainType.ts
+++ b/packages/indexer-database/src/migrations/1747773035048-hubPoolEventsChainType.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class HubPoolEventsChainType1747773035048 implements MigrationInterface {
+  name = "HubPoolEventsChainType1747773035048";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."root_bundle_executed" ALTER COLUMN "chainId" TYPE bigint`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."set_pool_rebalance_route" ALTER COLUMN "destinationChainId" TYPE bigint`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "evm"."root_bundle_executed" ALTER COLUMN "chainId" TYPE integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "evm"."set_pool_rebalance_route" ALTER COLUMN "destinationChainId" TYPE integer`,
+    );
+  }
+}


### PR DESCRIPTION
This PR changes the column type of `root_bundle_executed.chainId` and `set_pool_rebalance_route.destinationChainId` from `int` to `bigint`. This change is required because Solana's chain id is greater than the max allowed value in postgres int columns.