### PR TITLE
fix: handle zero address when formatting

### DIFF
--- a/packages/indexer/src/utils/adressUtils.ts
+++ b/packages/indexer/src/utils/adressUtils.ts
@@ -1,0 +1,20 @@
+import { utils, arch } from "@across-protocol/sdk";
+
+const { EvmAddress, SvmAddress, chainIsEvm, chainIsSvm, isZeroAddress } = utils;
+
+export function formatFromBytes32ToChainFormat(
+  bytes32Address: string,
+  chainId: number,
+) {
+  if (chainIsEvm(chainId)) {
+    return EvmAddress.from(bytes32Address, "base16").toEvmAddress();
+  } else if (chainIsSvm(chainId)) {
+    // Handle special case if address is the zero address
+    if (isZeroAddress(bytes32Address)) {
+      return arch.svm.SVM_DEFAULT_ADDRESS;
+    }
+    return SvmAddress.from(bytes32Address, "base16").toBase58();
+  } else {
+    throw new Error(`Unsupported chainId: ${chainId}`);
+  }
+}

--- a/packages/indexer/src/utils/index.ts
+++ b/packages/indexer/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./adressUtils";
 export * from "./contractUtils";
 export * from "./contractFactoryUtils";
 export * from "./bundleBuilderUtils";


### PR DESCRIPTION
This PR refactors the way we format address fields. It adds a new util function that we can reuse instead of having duplicated logic for each event. That function also handles the special case where we were trying to create an SVM address from the EVM zero address which was failing in sandbox.