### PR TITLE
fix: rename all transactions fields to contain "txnRef"

### DIFF
--- a/packages/indexer-api/src/dtos/deposits.dto.ts
+++ b/packages/indexer-api/src/dtos/deposits.dto.ts
@@ -49,7 +49,14 @@ export type DepositsParams = s.Infer<typeof DepositsParams>;
 export const DepositParams = s.object({
   depositId: s.optional(s.string()),
   originChainId: s.optional(stringToInt),
+  /**
+   * @deprecated Use depositTxnRef instead.
+   * Once with supporting SVM chains, all references
+   * to EVM terminology is being deprecated for more general terms.
+   * 
+   */
   depositTxHash: s.optional(s.string()),
+  depositTxnRef: s.optional(s.string()),
   relayDataHash: s.optional(s.string()),
   index: s.refine(
     s.defaulted(stringToInt, 0),

--- a/packages/indexer-api/src/dtos/deposits.dto.ts
+++ b/packages/indexer-api/src/dtos/deposits.dto.ts
@@ -53,7 +53,7 @@ export const DepositParams = s.object({
    * @deprecated Use depositTxnRef instead.
    * Once with supporting SVM chains, all references
    * to EVM terminology is being deprecated for more general terms.
-   * 
+   *
    */
   depositTxHash: s.optional(s.string()),
   depositTxnRef: s.optional(s.string()),

--- a/packages/indexer-api/src/services/deposits.ts
+++ b/packages/indexer-api/src/services/deposits.ts
@@ -187,6 +187,9 @@ export class DepositsService {
 
         return {
           ...deposit,
+          depositTxnRef: deposit.depositTxHash,
+          depositRefundTxnRef: deposit.depositRefundTxHash,
+          fillTxnRef: deposit.fillTx,
           originChainId: parseInt(deposit.originChainId),
           destinationChainId: parseInt(deposit.destinationChainId),
           speedups,
@@ -204,6 +207,7 @@ export class DepositsService {
       !(
         (params.depositId && params.originChainId) ||
         params.depositTxHash ||
+        params.depositTxnRef ||
         params.relayDataHash
       )
     ) {
@@ -236,6 +240,10 @@ export class DepositsService {
       queryBuilder.andWhere("rhi.depositTxHash = :depositTxHash", {
         depositTxHash: params.depositTxHash,
       });
+    } else if (params.depositTxnRef) {
+      queryBuilder.andWhere("rhi.depositTxHash = :depositTxnRef", {
+        depositTxnRef: params.depositTxnRef,
+      });
     }
 
     if (params.relayDataHash) {
@@ -264,9 +272,12 @@ export class DepositsService {
       originChainId: parseInt(relay.originChainId),
       depositId: relay.depositId,
       depositTxHash: relay.depositTxHash,
+      depositTxnRef: relay.depositTxHash,
       fillTx: relay.fillTxHash,
+      fillTxnRef: relay.fillTxHash,
       destinationChainId: parseInt(relay.destinationChainId),
       depositRefundTxHash: relay.depositRefundTxHash,
+      depositRefundTxnRef: relay.depositRefundTxHash,
       pagination: {
         currentIndex: params.index,
         maxIndex: numberMatchingRelays - 1,
@@ -291,6 +302,7 @@ export class DepositsService {
       !(
         (params.depositId && params.originChainId) ||
         params.depositTxHash ||
+        params.depositTxnRef ||
         params.relayDataHash
       )
     ) {
@@ -339,6 +351,10 @@ export class DepositsService {
       queryBuilder.andWhere("rhi.depositTxHash = :depositTxHash", {
         depositTxHash: params.depositTxHash,
       });
+    } else if (params.depositTxnRef) {
+      queryBuilder.andWhere("rhi.depositTxHash = :depositTxnRef", {
+        depositTxnRef: params.depositTxnRef,
+      });
     }
 
     if (params.relayDataHash) {
@@ -368,6 +384,9 @@ export class DepositsService {
     const result = {
       deposit: {
         ...relay,
+        depositTxnRef: relay.depositTxHash,
+        depositRefundTxnRef: relay.depositRefundTxHash,
+        fillTxnRef: relay.fillTxHash,
       },
       pagination: {
         currentIndex: params.index,
@@ -647,6 +666,8 @@ export class DepositsService {
     }
     if (params.depositTxHash) {
       return `depositStatus-${params.depositTxHash}-${params.index}`;
+    } else if (params.depositTxnRef) {
+      return `depositStatus-${params.depositTxnRef}-${params.index}`;
     }
     if (params.relayDataHash) {
       return `depositStatus-${params.relayDataHash}-${params.index}`;
@@ -665,6 +686,8 @@ export class DepositsService {
     }
     if (params.depositTxHash) {
       return `deposit-${params.depositTxHash}-${params.index}`;
+    } else if (params.depositTxnRef) {
+      return `deposit-${params.depositTxnRef}-${params.index}`;
     }
     if (params.relayDataHash) {
       return `deposit-${params.relayDataHash}-${params.index}`;


### PR DESCRIPTION
Once with supporting SVM chains, all references to EVM terminology is being deprecated for more general terms. This PR touches query parameters, caching keys and response fields.

`GET /deposit/status`

**query params**
- deprecate `depositTxHash` and add `depositTxnRef`

**response fields**
- deprecate `depositTxHash` and add `depositTxnRef`
- deprecate `fillTx` and add `fillTxnRef`
- deprecate `depositRefundTxHash` and add `depositRefundTxnRef`
---

`GET /deposit`

**query params**
- deprecate `depositTxHash` and add `depositTxnRef`

**response fields**
- deprecate `depositTxHash` and add `depositTxnRef`
- deprecate `depositRefundTxHash` and add `depositRefundTxnRef`
- deprecate `fillTx` and add `fillTxnRef`

---

`GET /deposits`

**response fields**
- deprecate `depositTxHash` and add `depositTxnRef`
- deprecate `depositRefundTxHash` and add `depositRefundTxnRef`
- deprecate `fillTx` and add `fillTxnRef`