### PR TITLE
feat: new address param for deposits endpoint

### DIFF
--- a/packages/indexer-api/src/dtos/deposits.dto.ts
+++ b/packages/indexer-api/src/dtos/deposits.dto.ts
@@ -26,6 +26,7 @@ const parseAddressField = s.coerce(s.string(), s.string(), (value) => {
 });
 
 export const DepositsParams = s.object({
+  address: s.optional(parseAddressField), // matches deposits where the address appears as either depositor or recipient
   depositor: s.optional(parseAddressField),
   recipient: s.optional(parseAddressField),
   originChainId: s.optional(stringToInt),

--- a/packages/indexer-api/src/dtos/deposits.dto.ts
+++ b/packages/indexer-api/src/dtos/deposits.dto.ts
@@ -26,7 +26,7 @@ const parseAddressField = s.coerce(s.string(), s.string(), (value) => {
 });
 
 export const DepositsParams = s.object({
-  address: s.optional(parseAddressField), // matches deposits where the address appears as either depositor or recipient
+  address: s.optional(parseAddressField), // matches deposits where provided address is either depositor or recipient
   depositor: s.optional(parseAddressField),
   recipient: s.optional(parseAddressField),
   originChainId: s.optional(stringToInt),

--- a/packages/indexer-api/src/services/deposits.ts
+++ b/packages/indexer-api/src/services/deposits.ts
@@ -112,6 +112,16 @@ export class DepositsService {
       });
     }
 
+    // Filter deposits by address - matches deposits where the address appears as either depositor or recipient
+    if (params.address) {
+      queryBuilder.andWhere(
+        "deposit.depositor = :address OR deposit.recipient = :address",
+        {
+          address: params.address,
+        },
+      );
+    }
+
     if (params.inputToken) {
       queryBuilder.andWhere("deposit.inputToken = :inputToken", {
         inputToken: params.inputToken,

--- a/packages/indexer-api/src/services/deposits.ts
+++ b/packages/indexer-api/src/services/deposits.ts
@@ -100,26 +100,26 @@ export class DepositsService {
         ...FilledRelayFields,
       ]);
 
-    if (params.depositor) {
-      queryBuilder.andWhere("deposit.depositor = :depositor", {
-        depositor: params.depositor,
-      });
-    }
-
-    if (params.recipient) {
-      queryBuilder.andWhere("deposit.recipient = :recipient", {
-        recipient: params.recipient,
-      });
-    }
-
-    // Filter deposits by address - matches deposits where the address appears as either depositor or recipient
     if (params.address) {
+      // Filter deposits by address - matches deposits where the provided address is either depositor or recipient
       queryBuilder.andWhere(
         "deposit.depositor = :address OR deposit.recipient = :address",
         {
           address: params.address,
         },
       );
+    } else {
+      if (params.depositor) {
+        queryBuilder.andWhere("deposit.depositor = :depositor", {
+          depositor: params.depositor,
+        });
+      }
+
+      if (params.recipient) {
+        queryBuilder.andWhere("deposit.recipient = :recipient", {
+          recipient: params.recipient,
+        });
+      }
     }
 
     if (params.inputToken) {

--- a/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
+++ b/packages/indexer-database/src/entities/evm/V3FundsDeposited.ts
@@ -21,6 +21,7 @@ import { RelayHashInfo } from "../RelayHashInfo";
 @Index("IX_v3FundsDeposited_finalised", ["finalised"])
 @Index("IX_v3FundsDeposited_blockTimestamp", ["blockTimestamp"])
 @Index("IX_v3FundsDeposited_depositor", ["depositor"])
+@Index("IX_v3FundsDeposited_recipient", ["recipient"])
 @Index("IX_v3FundsDeposited_destinationChainId", ["destinationChainId"])
 @Index("IX_deposits_block_chain_logIndex", [
   "blockNumber",

--- a/packages/indexer-database/src/migrations/1750776709049-DepositsRecipientIndex.ts
+++ b/packages/indexer-database/src/migrations/1750776709049-DepositsRecipientIndex.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DepositsRecipientIndex1750776709049 implements MigrationInterface {
+  name = "DepositsRecipientIndex1750776709049";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IX_v3FundsDeposited_recipient" ON "evm"."v3_funds_deposited" ("recipient") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "evm"."IX_v3FundsDeposited_recipient"`);
+  }
+}


### PR DESCRIPTION
This PR adds `address` as a query param for the `/deposits` endpoint. This param enables querying transactions where the provided address is either the depositor or the recipient. This will let us keep the same behavior we had in the transactions page when using the scraper.

It also adds the required index in the recipient column of the deposits table.