### PR TITLE
fix: fix index usage

### DIFF
--- a/packages/indexer-api/src/services/deposits.ts
+++ b/packages/indexer-api/src/services/deposits.ts
@@ -92,7 +92,7 @@ export class DepositsService {
         "fill",
         "fill.id = rhi.fillEventId",
       )
-      .orderBy("deposit.blockTimestamp", "DESC", "NULLS LAST")
+      .orderBy("deposit.blockTimestamp", "DESC")
       .select([
         ...DepositFields,
         ...RelayHashInfoFields,
@@ -168,6 +168,8 @@ export class DepositsService {
     if (params.limit) {
       queryBuilder.limit(params.limit);
     }
+
+    console.log(queryBuilder.getQueryAndParameters());
 
     const deposits: DepositReturnType[] = await queryBuilder.execute();
 

--- a/packages/indexer-api/src/services/deposits.ts
+++ b/packages/indexer-api/src/services/deposits.ts
@@ -169,8 +169,6 @@ export class DepositsService {
       queryBuilder.limit(params.limit);
     }
 
-    console.log(queryBuilder.getQueryAndParameters());
-
     const deposits: DepositReturnType[] = await queryBuilder.execute();
 
     // Fetch speedup events for each deposit


### PR DESCRIPTION
The index for `blockTimestamp` column was created for the default ascending order. This means that Postgres will store the **NULLS** at the end of the index. We can traverse the index in descending order, but in this case the **NULLS** are read **first**.

If we query data in descending order **BUT NULLS LAST**, the index is not used. This increased the response times to 2-3 minutes for the `/deposits` endpoint