### PR TITLE
fix: internal hash overflow errors

### DIFF
--- a/packages/indexer/src/database/SpokePoolRepository.ts
+++ b/packages/indexer/src/database/SpokePoolRepository.ts
@@ -197,19 +197,33 @@ export class SpokePoolRepository extends dbUtils.BlockchainEventRepository {
     lastFinalisedBlock: number,
   ) {
     const formattedEvents = requestedV3SlowFillEvents.map((event) => {
-      return {
-        ...this.formatRelayData(event),
-        destinationChainId: event.destinationChainId.toString(),
-        internalHash: utils.getInternalHash(
+      let internalHash: string | undefined;
+      try {
+        internalHash = utils.getInternalHash(
           event,
           event.messageHash,
           event.destinationChainId,
-        ),
+        );
+      } catch (error: any) {
+        if (error.reason === "overflow" && error.code === "NUMERIC_FAULT" && error.operation === "BigNumber.from") {
+          this.logger.warn({
+            at: "SpokePoolRepository#formatAndSaveRequestedV3SlowFillEvents",
+            message: "Overflow error when getting internal hash",
+            event,
+            error,
+          });
+          return undefined;
+        }
+      }
+      return {
+        ...this.formatRelayData(event),
+        destinationChainId: event.destinationChainId.toString(),
+        internalHash,
         message: event.messageHash,
         ...this.formatTxnData(event),
         finalised: event.blockNumber <= lastFinalisedBlock,
       };
-    });
+    }).filter((event) => event !== undefined);
     const chunkedEvents = across.utils.chunk(formattedEvents, this.chunkSize);
     const savedEvents = await Promise.all(
       chunkedEvents.map((eventsChunk) =>


### PR DESCRIPTION
An incorrect slow fill request event causes overflow errors when computing the relay hash. A hot fix for this is to ignore such events for now 

<img width="1225" height="577" alt="Screenshot 2025-07-17 at 12 45 54" src="https://github.com/user-attachments/assets/da46521b-40d4-47b1-ab58-b97156006245" />

<img width="604" height="298" alt="Screenshot 2025-07-17 at 12 48 29" src="https://github.com/user-attachments/assets/58206b98-8519-48eb-9554-61f0b2bfe30b" />

