### PR TITLE
feat: add starting block number configuration and event deletion logi…

### DIFF
--- a/packages/indexer/src/data-indexing/adapter/cctp-v2/service.ts
+++ b/packages/indexer/src/data-indexing/adapter/cctp-v2/service.ts
@@ -1,10 +1,35 @@
 import { ethers } from "ethers";
 import {
   CCTP_NO_DOMAIN,
+  CHAIN_IDs,
   PRODUCTION_NETWORKS,
   TEST_NETWORKS,
 } from "@across-protocol/constants";
 import * as across from "@across-protocol/sdk";
+
+// we need to fetch only recent events, so
+// roughly starting with date of Oct 1st, 2025
+const STARTING_BLOCK_NUMBERS = {
+  [CHAIN_IDs.ARBITRUM]: 384463853,
+  [CHAIN_IDs.BASE]: 36193725,
+  [CHAIN_IDs.HYPEREVM]: 15083577,
+  [CHAIN_IDs.INK]: 26328532,
+  [CHAIN_IDs.MAINNET]: 23474786,
+  [CHAIN_IDs.OPTIMISM]: 141788893,
+  [CHAIN_IDs.POLYGON]: 77089546,
+  [CHAIN_IDs.UNICHAIN]: 28500000,
+  [CHAIN_IDs.WORLD_CHAIN]: 19873068,
+};
+
+export function getIndexingStartBlockNumber(chainId: number) {
+  const blockNumber = STARTING_BLOCK_NUMBERS[chainId];
+  if (!blockNumber) {
+    throw new Error(
+      `No starting block number found for CCTP indexing on chainId: ${chainId}`,
+    );
+  }
+  return blockNumber;
+}
 
 /**
  * Converts a 32-byte hex string with padding to a standard ETH address.

--- a/packages/indexer/src/database/CctpRepository.ts
+++ b/packages/indexer/src/database/CctpRepository.ts
@@ -33,6 +33,51 @@ export class CCTPRepository extends dbUtils.BlockchainEventRepository {
     super(postgres, logger);
   }
 
+  public async deleteUnfinalisedCCTPEvents(
+    chainId: number,
+    lastFinalisedBlock: number,
+  ) {
+    const chainIdColumn = "chainId";
+    const [
+      depositForBurnEvents,
+      messageSentEvents,
+      mintAndWithdrawEvents,
+      messageReceivedEvents,
+    ] = await Promise.all([
+      this.deleteUnfinalisedEvents(
+        chainId,
+        chainIdColumn,
+        lastFinalisedBlock,
+        entities.DepositForBurn,
+      ),
+      this.deleteUnfinalisedEvents(
+        chainId,
+        chainIdColumn,
+        lastFinalisedBlock,
+        entities.MessageSent,
+      ),
+      this.deleteUnfinalisedEvents(
+        chainId,
+        chainIdColumn,
+        lastFinalisedBlock,
+        entities.MintAndWithdraw,
+      ),
+      this.deleteUnfinalisedEvents(
+        chainId,
+        chainIdColumn,
+        lastFinalisedBlock,
+        entities.MessageReceived,
+      ),
+    ]);
+
+    return {
+      depositForBurnEvents,
+      messageSentEvents,
+      mintAndWithdrawEvents,
+      messageReceivedEvents,
+    };
+  }
+
   public async formatAndSaveBurnEvents(
     burnEvents: BurnEventsPair[],
     lastFinalisedBlock: number,


### PR DESCRIPTION
### 🚀 Key Changes

**Starting Block Configuration:**
- Added `STARTING_BLOCK_NUMBERS` mapping for all supported chains (Arbitrum, Base, HyperEVM, Ink, Mainnet, Optimism, Polygon, Unichain, World Chain)
- Configured to start from October 1st, 2025 blocks to avoid indexing historical data

**Soft-delete logic for unfinalized events**
- Implemented `deleteUnfinalisedCCTPEvents()` method in `CCTPRepository`
- Automatically soft delete events from all CCTP entity types if they were not marked as "finalized" and event blockNumber < last finalized block for that chain (we consider such events as being re-org'd)
  - `DepositForBurn` events
  - `MessageSent` events  
  - `MintAndWithdraw` events
  - `MessageReceived` events
